### PR TITLE
feat: coverage audit gate + p3-baby-bear test stage

### DIFF
--- a/loop.py
+++ b/loop.py
@@ -60,6 +60,16 @@ BENCH_MUST_CONTAIN = ["coset_lde", "Radix2DitParallel"]
 # Files agent may WRITE (prefix match, relative to REPO_DIR)
 WRITABLE = ["dft/src/", "baby-bear/src/"]
 
+# Maps writable path prefixes to the crate whose tests cover them.
+# Update this when WRITABLE or run_tests() changes.
+TARGET_CRATE_MAP = {
+    "dft/src/":       "p3-dft",
+    "baby-bear/src/": "p3-baby-bear",
+}
+
+# Crates actively tested in run_tests(). Must be kept in sync manually.
+TESTED_CRATES = {"p3-dft", "p3-baby-bear", "p3-examples"}
+
 # Diff patterns that are never legitimate in a DFT arithmetic optimization.
 # A diff containing these is hard-rejected before testing.
 FORBIDDEN_DIFF_PATTERNS = [
@@ -369,6 +379,16 @@ def run_tests():
         print(f"  [test] FAILED (p3-dft debug):\n{out1[-800:]}", flush=True)
         return False, out1
 
+    # Stage 1.5: BabyBear field arithmetic tests
+    print("  [test] Stage 1.5/3: p3-baby-bear field tests (debug)...", flush=True)
+    rc_bb, out_bb = run_cmd(
+        ["cargo", "test", "-p", "p3-baby-bear", "--", "--quiet"],
+        timeout=120,
+    )
+    if rc_bb != 0:
+        print(f"  [test] FAILED (p3-baby-bear):\n{out_bb[-800:]}", flush=True)
+        return False, out1 + out_bb
+
     # Stage 2: same DFT tests under release profile
     # Catches debug_assertions divergence and optimisation-induced UB.
     # Note: cfg(test) is still set here; cfg(not(test)) split-brain is
@@ -394,7 +414,30 @@ def run_tests():
         print("  [test] All tests passed.", flush=True)
     else:
         print(f"  [test] FAILED (p3-examples):\n{out3[-800:]}", flush=True)
-    return passed, out1 + out2 + out3
+    return passed, out1 + out_bb + out2 + out3
+
+
+def audit_test_coverage():
+    """
+    Reads CLAUDE.md to find the Primary optimization targets, maps each to its
+    owning crate via TARGET_CRATE_MAP, and cross-references against TESTED_CRATES.
+
+    Returns a list of (path_prefix, missing_crate) tuples for any gaps found.
+    Returns an empty list if coverage is complete.
+    """
+    claude_md = CLAUDE_MD.read_text(encoding="utf-8")
+    # Extract the Primary: line, e.g. "Primary: dft/src/radix_2_dit_parallel.rs, ..."
+    primary_line = ""
+    for line in claude_md.splitlines():
+        if line.strip().startswith("Primary:"):
+            primary_line = line
+            break
+
+    gaps = []
+    for prefix, crate in TARGET_CRATE_MAP.items():
+        if prefix in primary_line and crate not in TESTED_CRATES:
+            gaps.append((prefix, crate))
+    return gaps
 
 
 # ── Git helpers ───────────────────────────────────────────────────────────────
@@ -757,6 +800,20 @@ def main():
             backup = LOG_FILE.with_suffix(f".{int(time.time())}.bak.jsonl")
             LOG_FILE.rename(backup)
             print(f"[init] Old log saved to {backup.name}")
+
+    # ── Coverage audit ────────────────────────────────────────────────────────
+    gaps = audit_test_coverage()
+    prov["coverage_gaps"] = [f"{p} -> {c}" for p, c in gaps]
+    prov["coverage_gap_acknowledged"] = False
+    if gaps:
+        print("[WARNING] Test coverage gaps detected:")
+        for path, crate in gaps:
+            print(f"  {path} is a Primary target but {crate} is not in run_tests()")
+        answer = input("Proceed anyway? [y/N] ").strip().lower()
+        if answer != "y":
+            sys.exit(1)
+        prov["coverage_gap_acknowledged"] = True
+    prov_file.write_text(json.dumps(prov, indent=2))
 
     # ── Establish baseline ────────────────────────────────────────────────────
     print("\n[init] Building baseline benchmark (this compiles from scratch)...")

--- a/test_loop.py
+++ b/test_loop.py
@@ -314,5 +314,55 @@ class TestInspectDiff(unittest.TestCase):
 
 
 
+class TestAuditTestCoverage(unittest.TestCase):
+    """Verify audit_test_coverage() detects missing crates from CLAUDE.md targets."""
+
+    def _run_audit(self, primary_line, tested_crates):
+        import loop
+        import unittest.mock as mock
+        claude_md = f"## Optimization Target\n\n{primary_line}\n"
+        fake_path = mock.MagicMock()
+        fake_path.read_text.return_value = claude_md
+        with mock.patch.object(loop, "CLAUDE_MD", fake_path), \
+             mock.patch.object(loop, "TESTED_CRATES", tested_crates):
+            return loop.audit_test_coverage()
+
+    def test_no_gaps_when_all_crates_tested(self):
+        gaps = self._run_audit(
+            "Primary: dft/src/radix_2_dit_parallel.rs, baby-bear/src/x86_64_avx512/",
+            {"p3-dft", "p3-baby-bear", "p3-examples"},
+        )
+        self.assertEqual(gaps, [])
+
+    def test_detects_missing_baby_bear(self):
+        gaps = self._run_audit(
+            "Primary: dft/src/radix_2_dit_parallel.rs, baby-bear/src/x86_64_avx512/",
+            {"p3-dft", "p3-examples"},
+        )
+        self.assertEqual(len(gaps), 1)
+        self.assertIn("baby-bear/src/", gaps[0][0])
+        self.assertIn("p3-baby-bear", gaps[0][1])
+
+    def test_detects_missing_dft(self):
+        gaps = self._run_audit(
+            "Primary: dft/src/radix_2_dit_parallel.rs",
+            {"p3-baby-bear", "p3-examples"},
+        )
+        self.assertEqual(len(gaps), 1)
+        self.assertIn("p3-dft", gaps[0][1])
+
+    def test_target_not_in_primary_line_ignored(self):
+        # baby-bear not in Primary line — no gap even if untested
+        gaps = self._run_audit(
+            "Primary: dft/src/radix_2_dit_parallel.rs",
+            {"p3-dft", "p3-examples"},
+        )
+        self.assertEqual(gaps, [])
+
+    def test_empty_primary_line_no_gaps(self):
+        gaps = self._run_audit("", {"p3-dft", "p3-examples"})
+        self.assertEqual(gaps, [])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Adds `audit_test_coverage()` — reads CLAUDE.md Primary targets, maps each to its owning crate via `TARGET_CRATE_MAP`, cross-references against `TESTED_CRATES`
- Pre-flight prompts `[y/N]` if gaps are found — human must explicitly acknowledge before the run proceeds
- Adds `p3-baby-bear` as Stage 1.5 in `run_tests()` — catches field arithmetic bugs in `baby-bear/src/x86_64_avx512/` that the DFT bitwise comparison alone would not reliably surface
- Logs `coverage_gaps` and `coverage_gap_acknowledged` to `run_provenance.json`
- 5 new tests for `audit_test_coverage()` (35 total, all passing)

## Motivation
`baby-bear/src/x86_64_avx512/` is a Primary target in CLAUDE.md but `p3-baby-bear` was never tested. The audit function makes this class of gap self-detecting — as targets evolve, the pre-flight will flag any mismatch between CLAUDE.md and the active test suite rather than relying on manual tracking.

## Test plan
- [x] Run `python test_loop.py -v` — 35 tests pass
- [x] Verify `[WARNING] Test coverage gaps detected` prompt appears when `TESTED_CRATES` is missing a target crate
- [x] Verify `y/N` default blocks the run on Enter without `y`
- [x] Verify `run_provenance.json` contains `coverage_gaps` and `coverage_gap_acknowledged` after a run

