### PR TITLE
Agent infra improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,8 @@ tests_guidance.md
 
 # Experiment logs (gitignored — table.md and *_kept/full.jsonl are tracked)
 experiment_logs/**/experiment_report.md
-experiment_logs/**/terminal.log
+experiment_logs/**/terminal*.log
+experiment_logs/**/terminal_report.md
 experiment_logs/**/*with_bug*.jsonl
 
 # Runtime files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,11 @@ not architectural restructuring.
 | Uniform-twiddle for `first_half_general_oop` layer 0 OOP | −0.71% |
 | Fuse first two layers of `first_half_general_oop` | −1.03% |
 
+### Non-hot-path butterfly changes (Round 3)
+| Idea | Regression |
+|------|-----------|
+| Pre-broadcast `apply_to_rows` for `DifButterfly`, `ScaledTwiddleFreeButterfly`, `DifButterflyZeros` | +1.36% — none of these are in the `coset_lde_batch` hot path; changes added overhead with no benefit |
+
 ### Low-level micro-optimizations (Round 1)
 | Idea | Regression |
 |------|-----------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ not architectural restructuring.
 ### Non-hot-path butterfly changes (Round 3)
 | Idea | Regression |
 |------|-----------|
-| Pre-broadcast `apply_to_rows` for `DifButterfly`, `ScaledTwiddleFreeButterfly`, `DifButterflyZeros` | +1.36% — none of these are in the `coset_lde_batch` hot path; changes added overhead with no benefit |
+| Pre-broadcast `apply_to_rows` for `DifButterfly`, `DifButterflyZeros` | +1.36% — none of these are in the `coset_lde_batch` hot path; changes added overhead with no benefit |
 
 ### `second_half_general` backwards flag / first-two-layers (Round 3)
 | Idea | Regression |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,36 +57,12 @@ monty-31/src/x86_64_avx512/   ← readable, NOT writable
 
 Primary: `dft/src/radix_2_dit_parallel.rs`, `dft/src/butterflies.rs`, `baby-bear/src/x86_64_avx512/`
 
-Exploration preference: `butterflies.rs` and `baby-bear/src/` have fewer attempted
-optimizations across both rounds. When two ideas are equally promising, prefer the one
-targeting these files over radix.
+## Proven Techniques
 
-## Optimization Search Space
-
-- Twiddle factor precomputation, storage layout, or broadcast hoisting
-- Eliminating redundant work per element (multiplications by 1, repeated broadcasts)
-- Cache-blocking the butterfly loops (twiddle factors accessed non-sequentially)
-- Exploiting BabyBear field structure in butterfly arithmetic
-- Parallelism granularity adjustments in `Radix2DitParallel`
-- Special-casing boundary layers (e.g. layer 0 twiddle = 1, last layer block size = 2)
-- Out-of-place vs in-place trade-offs for memory bandwidth
-
-## Proven Techniques (extend these first)
-
-These approaches produced measurable improvements. Before exploring new territory, check
-whether a symmetric path, adjacent layer, or related function is untried:
-
-- **Pre-broadcast twiddle into `F::Packing` before inner loop** (butterflies.rs) — eliminates
-  16 redundant scalar→vector broadcasts per row-pair at 256 cols/AVX512 width 16. Applied to
-  `DitButterfly`, `ScaledDitButterfly`. Check: are all butterfly types covered?
-- **TwiddleFreeButterfly for twiddle==1 layers** — layer 0 of `first_half` has `twiddles[0]=1`,
-  eliminates one Montgomery mul per element. Applied to `first_half` layer 0. Check: are there
-  other layers where twiddle is structurally 1?
-- **Merge 1/N scaling into first butterfly layer** (`ScaledDitButterfly`) — eliminates a
-  separate O(N) memory pass. Applied to `second_half`. Fully exploited.
-- **Last-layer fusion** (`dit_layer_rev_last`, `dit_layer_rev_last2`) — fusing the final 1-2
-  layers of `second_half_general` into a single pass worked (rounds 1+2). The 3-layer version
-  (-0.96%) did not. The OOP path was extended in iter 8.
+- **Pre-broadcast twiddle into `F::Packing` before inner loop** (butterflies.rs) — eliminates 16 redundant scalar→vector broadcasts per row-pair at 256 cols/AVX512 width 16. Applied to `DitButterfly`, `ScaledDitButterfly`.
+- **TwiddleFreeButterfly for twiddle==1 layers** — layer 0 of `first_half` has `twiddles[0]=1`, eliminates one Montgomery mul per element. Applied to `first_half` layer 0.
+- **Merge 1/N scaling into first butterfly layer** (`ScaledDitButterfly`) — eliminates a separate O(N) memory pass. Applied to `second_half`. Fully exploited.
+- **Last-layer fusion** (`dit_layer_rev_last`, `dit_layer_rev_last2`) — fusing the final 1-2 layers of `second_half_general` into a single pass worked (rounds 1+2). The 3-layer version (−0.96%) did not. The OOP path was extended in iter 8.
 
 ## Known Dead Ends
 
@@ -136,8 +112,6 @@ not architectural restructuring.
 | Idea | Regression |
 |------|-----------|
 | Manual loop unroll | −49.4% — LLVM handles ILP; manual unrolling broke the vectorizer |
-| Forced inlining via `#[inline(always)]` | Regressed — LLVM already making good inlining decisions |
-| Remove `backwards` bool from `dit_layer_rev` | Flag was doing real work, removal broke correctness paths |
 
 ## Surgical Precision Principle
 
@@ -146,12 +120,6 @@ regresses 0.4–2.0%. The compiler cannot optimize manually-restructured iterato
 well as the original. **A change is surgical if it touches fewer than ~50 lines and targets a
 specific hot path.** If your idea requires a full-file rewrite, find the minimal targeted
 version first.
-
-## Primary Targets Still Unexplored
-
-- `butterflies.rs` — directly modifying butterfly arithmetic (Round 1 wrote to it; Round 2
-  only *read* it to inform radix changes but never wrote to it as a primary target)
-- `baby-bear/src/x86_64_avx512/` — see AVX512 guide below before targeting this
 
 ## Promising Ideas Interrupted by Token Budget (Round 3)
 
@@ -171,27 +139,11 @@ Pursue them before exploring new territory.
   reordering stores (`*x_1` before `*x_2`) or separating the two mul chains improves CPU
   pipeline utilization.
 
-## AVX512 Arithmetic — How to Navigate It
+## AVX512 Arithmetic
 
-`baby-bear/src/x86_64_avx512/packing.rs` is the correct entry point (37 lines) — it
-defines the type alias and BabyBear-specific constants used throughout the DFT crate.
-Read it first to understand the type, then follow into monty-31 for the arithmetic.
+Entry point: `baby-bear/src/x86_64_avx512/packing.rs` (37 lines) — type alias + BabyBear constants. AVX512 arithmetic lives in `monty-31/src/x86_64_avx512/` (readable, **not writable**):
 
-The actual AVX512 arithmetic is in **`monty-31/src/x86_64_avx512/`** (readable,
-not writable). Read these when you need to understand the field arithmetic chain:
+- `packing.rs` — `mul` at line 524: 6.5 cyc/vec, 21 cyc latency, already expert-optimized. Uses `confuse_compiler` to avoid `vpmullq`, underflow check to relieve port 0 pressure.
+- `utils.rs` — `halve_avx512` (2 cyc/vec), `mul_neg_2exp_neg_n_avx512` (3 cyc/vec, 9 cyc latency), `mul_neg_2exp_neg_two_adicity_avx512` (3 cyc/vec, 5 cyc latency).
 
-- **`monty-31/src/x86_64_avx512/packing.rs`** (1672 lines) — `PackedMontyField31AVX512`
-  arithmetic. Key function: `mul` at line 524 — already expert-optimized at 6.5 cyc/vec,
-  21 cyc latency, 13 instructions. Uses `vmovshdup`+`vpmuludq` even/odd split,
-  `confuse_compiler` to avoid `vpmullq`, underflow check instead of `vpminud` to relieve
-  port 0 pressure. **You cannot write this file.**
-- **`monty-31/src/x86_64_avx512/utils.rs`** — `halve_avx512` (2 cyc/vec),
-  `mul_neg_2exp_neg_n_avx512` (3 cyc/vec, 9 cyc latency),
-  `mul_neg_2exp_neg_two_adicity_avx512` (3 cyc/vec, 5 cyc latency).
-  **You cannot write this file.**
-
-**The actionable target is `butterflies.rs`** (readable and writable). The
-`DitButterfly::apply_to_rows` hot loop invokes packed field `mul` once per element pair.
-Reducing the number of `mul` calls per butterfly, fusing operations, or restructuring
-how twiddles are passed in are all achievable within the writable set without touching
-the AVX512 internals.
+Use `get_assembly` to verify actual codegen before assuming what the compiler emits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,14 @@ You are an expert Rust systems programmer. Your job is to make the Plonky3 DFT/N
 implementation faster — specifically `coset_lde_batch` on BabyBear at 2^20 × 256 columns
 using `Radix2DitParallel`.
 
+## Tools Available
+
+- `read_file` — read source files
+- `write_file` — write changes (only dft/src/ and baby-bear/src/)
+- `list_dir` — list directory contents
+- `read_experiment_diff` — read the full diff from a previous iteration
+- `get_assembly` — get x86-64 assembly for a function (e.g. `get_assembly("dit_layer_rev_last2_flat")`). **Use this before submitting any change that relies on compiler behavior** — verify the assembly before and after to confirm your optimization isn't redundant. Call it at most once or twice per iteration — it is slow and token-expensive.
+
 ## Current Codebase State
 The codebase includes all kept improvements from Round 1 and Round 2. The benchmark baseline
 reflects this. You are optimizing on top of these already-applied changes — do not re-implement

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ using `Radix2DitParallel`.
 - `get_assembly` — get x86-64 assembly for a function (e.g. `get_assembly("dit_layer_rev_last2_flat")`). **Use this before submitting any change that relies on compiler behavior** — verify the assembly before and after to confirm your optimization isn't redundant. Call it at most once or twice per iteration — it is slow and token-expensive.
 
 ## Current Codebase State
-The codebase includes all kept improvements from Round 1 and Round 2. The benchmark baseline
+The codebase includes all kept improvements from Rounds 1, 2, and 3. The benchmark baseline
 reflects this. You are optimizing on top of these already-applied changes — do not re-implement
 or re-verify them, focus on what remains unexplored.
 
@@ -55,7 +55,15 @@ monty-31/src/x86_64_avx512/   ← readable, NOT writable
 
 ## Optimization Target
 
-Primary: `dft/src/radix_2_dit_parallel.rs`, `dft/src/butterflies.rs`, `baby-bear/src/x86_64_avx512/`
+**Mandatory first 3 iterations: `baby-bear/src/baby_bear.rs`**
+BabyBear's prime `p = 2^31 - 2^27 + 1` has structure that may allow cheaper modular reduction
+than the generic Montgomery path. This area has never been touched across 114 iterations.
+Start by calling `get_assembly` on BabyBear-specific arithmetic functions to determine whether
+the compiler exploits the prime structure or falls back to generic paths. The writable surface
+is `baby-bear/src/baby_bear.rs` only (the monty-31 AVX512 implementation is readable but not writable).
+
+After baby-bear is exhausted or confirmed optimal, secondary targets:
+`dft/src/radix_2_dit_parallel.rs`, `dft/src/butterflies.rs`
 
 ## Proven Techniques
 
@@ -109,6 +117,14 @@ not architectural restructuring.
 |------|-----------|
 | Pre-broadcast `apply_to_rows` for `DifButterfly`, `ScaledTwiddleFreeButterfly`, `DifButterflyZeros` | +1.36% — none of these are in the `coset_lde_batch` hot path; changes added overhead with no benefit |
 
+### `second_half_general` backwards flag / first-two-layers (Round 3)
+| Idea | Regression |
+|------|-----------|
+| Remove `backwards` flag from `second_half_general` loop (extensions to second_half + first_half_general) | −1.64% to −1.87% — four attempts across iters 17-20, all regressed |
+| Remove `backwards` flag from `first_half_general` | −0.90% — symmetry argument without assembly evidence; codegen differs |
+| First-two-layers fusion in `second_half_general` (`dit_layer_rev_first2_general`) | −0.15% — clean retry without debug_assert still regressed; cache pressure confirmed |
+| ALU instruction reordering in `dit_layer_rev_last2*` | −0.74% — LLVM already handles instruction scheduling; no headroom |
+
 ### Low-level micro-optimizations (Round 1)
 | Idea | Regression |
 |------|-----------|
@@ -121,23 +137,6 @@ regresses 0.4–2.0%. The compiler cannot optimize manually-restructured iterato
 well as the original. **A change is surgical if it touches fewer than ~50 lines and targets a
 specific hot path.** If your idea requires a full-file rewrite, find the minimal targeted
 version first.
-
-## Promising Ideas Interrupted by Token Budget (Round 3)
-
-These ideas were under active analysis when the token budget ran out. They were NOT tried.
-Pursue them before exploring new territory.
-
-- **First-two-layers fusion in `second_half_general`** (`dit_layer_rev_first2_general`) — fuse `layer_rev == log_h-1-mid` and `layer_rev == log_h-2-mid` into a single pass processing all 4 quarter-groups simultaneously. Halves memory traffic for these two layers (2 MiB vs 4 MiB per thread), analogous to the existing `dit_layer_rev_last2` fusion. Cache analysis confirmed 4 streams × 256 KiB fits within L3 per thread. **Previously attempted but rejected by forbidden pattern gate — retry without any `debug_assert!`.**
-
-- **`baby-bear/src/baby_bear.rs` field arithmetic specialization** — BabyBear's prime `p = 2^31 - 2^27 + 1` has structure that may allow cheaper modular reduction than the generic Montgomery path. The writable surface is `baby-bear/src/baby_bear.rs`. Use `get_assembly` on BabyBear-specific arithmetic functions to identify whether the compiler is exploiting the prime structure or falling back to generic paths. **Entirely unexplored — no attempts yet.**
-
-- **ALU dependency chain in `dit_layer_rev_last2_flat`** — full 12-step dependency trace confirmed
-  15-cycle critical path. The two-stage butterfly structure creates a serial mul dependency
-  (`mul(r2t/r3t)` → `add/sub` → `mul(r1t/r3t)` → `add/sub`) that cannot be eliminated. However,
-  the analysis was cut off before identifying whether instruction reordering within each stage
-  could improve throughput on the 8-cycle bound (4 muls at 0.5 mul/cycle). Explore whether
-  reordering stores (`*x_1` before `*x_2`) or separating the two mul chains improves CPU
-  pipeline utilization.
 
 ## AVX512 Arithmetic
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ not architectural restructuring.
 |------|-----------|
 | `dit_layer_rev_forward` — pre-reverse twiddle slice for sequential prefetcher access (tried **twice**, iters 9 and 11) | −0.97% |
 | `dit_layer_rev_pair32` — fuse `layer_rev==3` and `layer_rev==2` | −1.22% |
+| Replace `twiddles0.chunks(2)` with `enumerate` + direct index `twiddles0[2*i]`/`twiddles0[2*i+1]` in `dit_layer_rev_last2`, `dit_layer_rev_last2_flat`, `dit_layer_rev_last2_flat_scaled` | +3.3% — LLVM already optimizes `chunks(2)` well; `enumerate` counter + multiply-by-2 adds overhead. Consistent regression across all sizes (p=0.00). **Note:** `unsafe` direct indexing (no bounds check) is a different experiment, not yet tried. |
 
 ### `first_half_general` layer fusion
 | Idea | Regression |
@@ -126,10 +127,7 @@ version first.
 These ideas were under active analysis when the token budget ran out. They were NOT tried.
 Pursue them before exploring new territory.
 
-- **`dit_layer_rev_last2_flat` direct indexing** — the function currently uses `twiddles0.chunks(2)`
-  to iterate over twiddle pairs, creating a chunk iterator with per-block overhead. For 256 mega-blocks
-  per thread, this is 256 iterator constructions. Direct pointer indexing into the twiddle slice may
-  reduce this overhead. Surgical target: the outer loop in `dit_layer_rev_last2_flat`.
+- **First-two-layers fusion in `second_half_general`** (`dit_layer_rev_first2_general`) — fuse `layer_rev == log_h-1-mid` and `layer_rev == log_h-2-mid` into a single pass processing all 4 quarter-groups simultaneously. Halves memory traffic for these two layers (2 MiB vs 4 MiB per thread), analogous to the existing `dit_layer_rev_last2` fusion. Cache analysis confirmed 4 streams × 256 KiB fits within L3 per thread. **Previously attempted but rejected by forbidden pattern gate — retry without any `debug_assert!`.**
 
 - **ALU dependency chain in `dit_layer_rev_last2_flat`** — full 12-step dependency trace confirmed
   15-cycle critical path. The two-stage butterfly structure creates a serial mul dependency

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,11 @@ You are an expert Rust systems programmer. Your job is to make the Plonky3 DFT/N
 implementation faster — specifically `coset_lde_batch` on BabyBear at 2^20 × 256 columns
 using `Radix2DitParallel`.
 
+## Current Codebase State
+The codebase includes all kept improvements from Round 1 and Round 2. The benchmark baseline
+reflects this. You are optimizing on top of these already-applied changes — do not re-implement
+or re-verify them, focus on what remains unexplored.
+
 ## Hard Constraints (never violate)
 
 1. **No security parameter changes** — do not touch FRI query count, blowup factor,
@@ -139,6 +144,24 @@ version first.
 - `butterflies.rs` — directly modifying butterfly arithmetic (Round 1 wrote to it; Round 2
   only *read* it to inform radix changes but never wrote to it as a primary target)
 - `baby-bear/src/x86_64_avx512/` — see AVX512 guide below before targeting this
+
+## Promising Ideas Interrupted by Token Budget (Round 3)
+
+These ideas were under active analysis when the token budget ran out. They were NOT tried.
+Pursue them before exploring new territory.
+
+- **`dit_layer_rev_last2_flat` direct indexing** — the function currently uses `twiddles0.chunks(2)`
+  to iterate over twiddle pairs, creating a chunk iterator with per-block overhead. For 256 mega-blocks
+  per thread, this is 256 iterator constructions. Direct pointer indexing into the twiddle slice may
+  reduce this overhead. Surgical target: the outer loop in `dit_layer_rev_last2_flat`.
+
+- **ALU dependency chain in `dit_layer_rev_last2_flat`** — full 12-step dependency trace confirmed
+  15-cycle critical path. The two-stage butterfly structure creates a serial mul dependency
+  (`mul(r2t/r3t)` → `add/sub` → `mul(r1t/r3t)` → `add/sub`) that cannot be eliminated. However,
+  the analysis was cut off before identifying whether instruction reordering within each stage
+  could improve throughput on the 8-cycle bound (4 muls at 0.5 mul/cycle). Explore whether
+  reordering stores (`*x_1` before `*x_2`) or separating the two mul chains improves CPU
+  pipeline utilization.
 
 ## AVX512 Arithmetic — How to Navigate It
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,8 @@ Pursue them before exploring new territory.
 
 - **First-two-layers fusion in `second_half_general`** (`dit_layer_rev_first2_general`) — fuse `layer_rev == log_h-1-mid` and `layer_rev == log_h-2-mid` into a single pass processing all 4 quarter-groups simultaneously. Halves memory traffic for these two layers (2 MiB vs 4 MiB per thread), analogous to the existing `dit_layer_rev_last2` fusion. Cache analysis confirmed 4 streams × 256 KiB fits within L3 per thread. **Previously attempted but rejected by forbidden pattern gate — retry without any `debug_assert!`.**
 
+- **`baby-bear/src/baby_bear.rs` field arithmetic specialization** — BabyBear's prime `p = 2^31 - 2^27 + 1` has structure that may allow cheaper modular reduction than the generic Montgomery path. The writable surface is `baby-bear/src/baby_bear.rs`. Use `get_assembly` on BabyBear-specific arithmetic functions to identify whether the compiler is exploiting the prime structure or falling back to generic paths. **Entirely unexplored — no attempts yet.**
+
 - **ALU dependency chain in `dit_layer_rev_last2_flat`** — full 12-step dependency trace confirmed
   15-cycle critical path. The two-stage butterfly structure creates a serial mul dependency
   (`mul(r2t/r3t)` → `add/sub` → `mul(r1t/r3t)` → `add/sub`) that cannot be eliminated. However,

--- a/experiment_logs/experiment_3/iter_20_report.md
+++ b/experiment_logs/experiment_3/iter_20_report.md
@@ -1,0 +1,140 @@
+# Experiment 3 — Iter 20 Report
+
+## Results Summary
+
+| Iter | Outcome | Δ% | Score | Idea |
+|------|---------|----|-------|------|
+| 01 | REVERT | -1.36% | 2701.80ms | Pre-broadcast apply_to_rows to DifButterfly (non-hot-path) |
+| 02 | REVERT | -0.22% | 2655.30ms | apply_to_rows override to TwiddleFreeButterfly |
+| 03 | REVERT | -0.17% | 2654.00ms | Load *x_1 into local before *x_2 * twiddle |
+| 04 | REVERT | -0.02% | 2650.00ms | apply_to_rows_oop to ScaledDitButterfly |
+| 05 | REVERT | -3.23% | 2735.10ms | apply_to_rows_oop to TwiddleFreeButterfly |
+| 06 | REVERT | -0.22% | 2698.90ms | chunks(2) → chunks_exact(2) |
+| 07 | REVERT | -0.10% | 2695.70ms | dit_layer_oop_uniform_twiddle |
+| **08** | **KEPT** | **+0.56%** | **2677.90ms** | chunks(2) → step_by(2) zip iterators |
+| 09 | FORBIDDEN | — | — | First-two-layers fusion (debug_assert gate) |
+| 10 | REVERT | -0.74% | 2697.60ms | ALU instruction reordering in dit_layer_rev_last2* |
+| 11 | THRESHOLD | +0.11% | 2662.80ms | (no IDEA line — hit max_tokens) |
+| 12 | REVERT | -0.15% | 2669.80ms | First-two-layers fusion (clean retry, cache pressure) |
+| 13 | REVERT | -0.18% | 2670.60ms | Slice twiddles1[..n_blocks] in dit_layer_rev_last2* |
+| 14 | REVERT | -0.78% | 2686.70ms | Replace step_by(2) with raw pointer iterators |
+| 15 | TESTS_FAILED | — | — | Replace outer loop in dit_layer_rev_last2 with parallel |
+| **16** | **KEPT** | **+1.40%** | **2628.40ms** | Remove backwards flag from second_half_general |
+| 17 | REVERT | -1.64% | 2671.50ms | Extend backwards flag removal to second_half + first_half_general |
+| 18 | REVERT | -1.87% | 2677.60ms | Backwards flag removal from second_half general layers loop |
+| 19 | REVERT | -1.54% | 2668.80ms | Peel first iteration (layer==mid) from second_half_general |
+| 20 | REVERT | -0.90% | 2652.00ms | Backwards flag removal from first_half_general |
+
+**Baseline:** 2665.60ms | **Best:** 2628.40ms | **Exp 3 gain: +1.40%**
+
+---
+
+## Cost & Token Stats
+
+| Metric | Value |
+|--------|-------|
+| Total cost | $44.80 |
+| Avg cost/iter | $2.24 |
+| Avg input tokens | 552,475 |
+| Avg output tokens | 38,835 |
+| Avg agent time | 601s (~10 min/iter) |
+
+Token usage is high — avg 552k input tokens. Trimming CLAUDE.md and removing agent_thinking (implemented mid-run) should reduce this for the next run.
+
+---
+
+## Key Observations
+
+### 1. Two genuine improvements, both from unexpected directions
+- **Iter 8** (+0.56%): step_by(2) zip — compiler codegen difference vs chunks(2) confirmed via assembly tool
+- **Iter 16** (+1.40%): backwards flag removal — largest single gain, found after exhausting the promising ideas list without any CLAUDE.md hint
+
+Iter 16 is notable: the backwards flag was considered a structural feature, not a performance knob. The agent found it independently through fresh exploration.
+
+### 2. Extension fixation after iter 16
+Iters 17-20 all attempt to extend the backwards flag removal to other code paths. All regressed. The agent spent 4 consecutive iters on one dead idea family after a success. The prompt's extension nudge ("look for symmetric paths, adjacent layers") is actively causing this.
+
+**Action required:** Remove extension nudge. Add cooldown rule: max 1 extension attempt per idea before moving on.
+
+### 3. Promising ideas list exhausted
+- ALU dependency reordering (iter 10): flat — LLVM already handles scheduling
+- First-two-layers fusion (iters 9 + 12): cache pressure killed it on clean retry
+- step_by(2) direct pointer (iter 14): regression vs the kept step_by(2) zip
+
+Only baby-bear field specialization remains genuinely unexplored. CLAUDE.md promising ideas section needs pruning.
+
+### 4. Infrastructure working correctly
+- Forbidden pattern gate caught debug_assert (iter 9) — clean retry confirmed the gate was right
+- Assembly tool used every run — no longer reasoning blind about compiler behavior
+- Recovery prompt continued in-progress ideas (iters 10-11)
+- Overload retry (status=200 mid-stream) caught correctly after fix
+- Iter 15 tests failed cleanly — parallel outer loop broke correctness, correctly rejected
+
+### 5. What points in a different direction
+- **Biggest gain came from outside the curated list** — suggests less guidance may enable more novel discovery
+- **Baby-bear = 0 of 20 iters** — CLAUDE.md nudge added too late; needs to be a mandatory first target next run
+- **Extension rate post-improvement: 80%** (4/5 iters after iter 16) — critical waste for long unsupervised runs
+
+---
+
+## Total Performance Across All Experiments
+
+| Round | Iters | Kept | Baseline | Best | Gain | Cumulative | Cost |
+|-------|-------|------|----------|------|------|------------|------|
+| Round 1 | 74 | 5 | 2724.4ms | 2642.8ms | −3.00% | −3.00% | ~$0 (old API) |
+| Round 2 | 20 | 4 | 2667.8ms | 2638.0ms | −1.12% | −4.10% | ~$0 (old API) |
+| Round 3 (Exp 3) | 20 | 2 | 2665.6ms | 2628.4ms | −1.40% | ~−3.52% at 2^20 | $44.80 |
+| **Total** | **114** | **11** | **2724.4ms** | **2628.4ms** | **−3.52% at 2^20** | | **~$45** |
+
+**Absolute cumulative gain: 2724.4ms → 2628.4ms = −3.52% at 2^20**
+
+Note: per-round gains (−3.00%, −1.12%, −1.40%) cannot be summed to 5.52%. Two reasons: (1) baselines drifted +25ms between sessions due to server thermal/memory state, so each round's gain is measured against a slightly worse starting point; (2) percentage gains compound, not add. The 3.52% absolute is the only honest cross-round number.
+
+### Multi-size validation (after Round 2)
+
+| Size | Change | Significant? |
+|------|--------|-------------|
+| 2^16 × 256 | −3.78% | Yes (p=0.00) |
+| 2^18 × 256 | −2.21% | Borderline (p=0.02) |
+| 2^20 × 256 | −1.06% | Borderline (p=0.03) |
+| **2^22 × 256** | **−8.57%** | **Yes (p=0.00)** |
+
+Gains amplify at larger sizes where working sets exceed L3 cache. Round 3 improvements not yet validated multi-size.
+
+Notes:
+- Round 3 gain (−1.40%) is within-session relative. Cumulative −3.52% is cross-round, not head-to-head validated.
+- Rounds 1+2 used old API pricing (pre-Sonnet 4.6 rates); Round 3 = $44.80 at current rates
+- Win rate: Round 1 = 5/74 = 6.8%, Round 2 = 4/20 = 20%, Round 3 = 2/20 = 10%
+- Overall: 11/114 = **9.6% win rate**
+
+### Efficiency trend
+Round 1: 5/74 = 6.8% — richest search space, lower-hanging fruit
+Round 2: 4/20 = 20% — structured first-half/second-half fusion opportunities, targeted approach
+Round 3: 2/20 = 10% — harder frontier, better infrastructure (assembly tool, forbidden gate, recovery prompt)
+
+Win rate holding despite harder search space. Infrastructure improvements appear to offset the harder optimization frontier.
+
+---
+
+---
+
+## Terminal Log Behavioral Analysis (Haiku summary)
+
+### Agent behavior patterns observed
+
+**Assembly tool underused in early iters (1-7):** Agent read files extensively but did not call `get_assembly` proactively before submitting changes. This led to submitting ideas that relied on unverified compiler assumptions. Assembly tool adoption improved in later iters.
+
+**Deadlock self-recognition (iter ~8):** Agent explicitly stated "I genuinely think all the major hot-path optimizations are either already implemented or explicitly listed as dead ends" and acknowledged being in analytical circles. Shifted strategy to grepping for missed patterns rather than structural changes. This is a healthy signal — agent aware of its own dead ends.
+
+**Symmetry assumption without verification (iter 20):** The backwards flag removal was applied to `first_half_general` using pure symmetry reasoning ("if it worked for second_half_general, it should work here") without assembly comparison. Regressed -0.90%. Confirms: symmetry arguments need assembly verification before submission.
+
+**Theory-driven reasoning strength:** Agent performed detailed algebraic analysis (butterfly operations, memory bandwidth estimates: ~20 GiB inverse DFT, ~80 GiB forward DFTs) and correctly concluded bandwidth is the bottleneck. Correctness reasoning was strong throughout.
+
+**No infrastructure events in later iters:** No overload retries, no forbidden pattern triggers, no recovery prompts in iters 13-20. Clean run after the overload period.
+
+### Behavioral recommendation for next run
+- Make `get_assembly` mandatory before any structural change (add to prompt: "call get_assembly before write_file")
+- Symmetry arguments explicitly require assembly evidence in the diff reasoning
+- Agent's deadlock self-recognition is a feature — consider surfacing it as an explicit "no improvement" output that triggers a prompt refresh
+
+*Report complete.*

--- a/improvement_ideas.md
+++ b/improvement_ideas.md
@@ -1295,3 +1295,27 @@ Acceptable since recovery agent should do 1-2 targeted reads anyway.
 
 **Note:** Current injection of last thinking block into existing history is the first step.
 Fresh context reset is the next improvement once injection is validated.
+
+## Dead end and promising idea classification methodology
+
+**Context:** Current dead end table prunes ideas after a single failed attempt. This is too
+aggressive — one regression or one forbidden pattern rejection is insufficient signal.
+Conversely, promising ideas are added manually and informally, with no entry criteria.
+
+**Dead end classification — proposed methodology:**
+- Require 3+ attempts with meaningfully different implementations before declaring dead end
+- Each entry must note WHY it failed: regression / forbidden pattern / compile error
+- A single forbidden pattern rejection is NOT a dead end — it means the idea needs a clean retry
+- A single marginal regression (<1%) is NOT a dead end — LLVM behavior varies by scale and implementation approach
+- Clear dead end signals: 2+ regressions with different implementations, or 1 large regression (>2%) with assembly-confirmed explanation
+
+**Promising idea classification — proposed methodology:**
+- Must have a structural argument (not just "might be faster")
+- Must not duplicate a confirmed dead end (structurally identical = same dead end)
+- Must note what was interrupted / why it wasn't completed
+- Include explicit warnings for known failure modes (e.g. "avoid debug_assert")
+
+**Future automation:**
+- Agent could self-classify after each iter: "this is a dead end because X" or "this needs retry because Y"
+- Loop could maintain a structured JSON of ideas with attempt counts and failure reasons
+- Human review gate before promoting to dead end (similar to the y/N coverage audit)

--- a/improvement_ideas.md
+++ b/improvement_ideas.md
@@ -1269,3 +1269,29 @@ compilation bugs; this catches everything else.
 
 **Priority:** Medium — implement before Opus run where iteration cost is significantly
 higher. A failed Opus iteration is ~10x more expensive than a Sonnet one.
+
+## Fresh context at recovery prompt (loop.py change) — HIGH PRIORITY
+
+**Problem:** Recovery prompt currently appends to the full message history (~150-200k tokens
+accumulated from file reads, tool results, prior reasoning turns). The recovery agent has
+to process all of this to find its direction, and often still pivots to a safe fallback.
+
+**Idea:** At recovery time, discard the accumulated message history and start fresh with:
+1. The original initial prompt (CLAUDE.md + experiment history + task description)
+2. The last reasoning block from `all_text_blocks` as explicit context
+3. The write instruction
+
+**Why it's better:**
+- 10x cheaper input tokens (~15-20k vs 150-200k)
+- Agent isn't distracted by 150k of accumulated tool results
+- Last thinking block gives it exactly what it needs to continue
+- Surgical re-reads are cheap if it needs code context
+
+**Implementation:** Save initial prompt in a variable at iteration start. At recovery,
+rebuild `messages = [initial_prompt_msg, recovery_msg]` instead of appending.
+
+**Risk:** Agent loses within-iteration tool results — must re-read files it already read.
+Acceptable since recovery agent should do 1-2 targeted reads anyway.
+
+**Note:** Current injection of last thinking block into existing history is the first step.
+Fresh context reset is the next improvement once injection is validated.

--- a/loop.py
+++ b/loop.py
@@ -657,8 +657,6 @@ Process:
 
 **Slice large ideas**: If your idea requires changing more than ~50 lines, find the minimal targeted version first. A small near-miss on the right function is more valuable than a large rewrite.
 
-**Extend kept changes**: Look at the kept improvements in the history. Ask: is there a symmetric path, related function, or adjacent layer where the same technique applies?
-
 **You must always make a change.**
 """
 

--- a/loop.py
+++ b/loop.py
@@ -153,6 +153,30 @@ TOOLS = [
         }
     },
     {
+        "name": "get_assembly",
+        "description": (
+            "Get the x86-64 assembly output for a specific function in the Plonky3 DFT crate. "
+            "Use this to verify what LLVM actually emits for a hot-path function — before and after "
+            "a change — to confirm whether your optimization is redundant or genuinely improves codegen. "
+            "Requires cargo-show-asm to be installed (`cargo install cargo-show-asm`). "
+            "Output is capped at 300 lines to avoid token waste."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "function": {
+                    "type": "string",
+                    "description": (
+                        "Function name filter — a substring of the fully-qualified function name. "
+                        "E.g. 'dit_layer_rev_last2_flat' or 'DitButterfly::apply_to_rows'. "
+                        "Use a specific name to avoid too many matches."
+                    )
+                }
+            },
+            "required": ["function"]
+        }
+    },
+    {
         "name": "read_experiment_diff",
         "description": (
             "Read the full code diff from a previous experiment iteration. "
@@ -214,6 +238,34 @@ def tool_read_experiment_diff(iteration: int) -> str:
     return f"ERROR: Iteration {iteration} not found in experiment log."
 
 
+def tool_get_assembly(function: str) -> str:
+    """
+    Run cargo-show-asm for a function name filter and return the assembly output.
+    Caps output at 300 lines to avoid token waste.
+    """
+    ASM_LINE_LIMIT = 300
+    rc, out = run_cmd(
+        ["cargo", "asm", "-p", "p3-dft", "--features", "p3-dft/parallel",
+         "--release", function],
+        timeout=120,
+    )
+    if rc != 0:
+        # cargo-show-asm exits non-zero when multiple matches found — output is still useful
+        lines = out.splitlines()
+        if not lines:
+            return (
+                f"ERROR: cargo asm failed for '{function}'.\n"
+                "Ensure cargo-show-asm is installed: cargo install cargo-show-asm\n"
+                f"Output: {out[:500]}"
+            )
+    lines = out.splitlines()
+    if len(lines) > ASM_LINE_LIMIT:
+        truncated = len(lines) - ASM_LINE_LIMIT
+        lines = lines[:ASM_LINE_LIMIT]
+        lines.append(f"\n... ({truncated} lines truncated — use a more specific function name)")
+    return "\n".join(lines)
+
+
 def tool_write_file(path: str, content: str) -> str:
     if any(path.startswith(p) for p in WRITABLE):
         full = (REPO_DIR / path).resolve()
@@ -252,6 +304,11 @@ def execute_tool(name: str, inputs: dict) -> str:
         if not path:
             return "ERROR: list_dir requires a 'path' argument."
         return tool_list_dir(path)
+    elif name == "get_assembly":
+        function = inputs.get("function")
+        if not function:
+            return "ERROR: get_assembly requires a 'function' argument."
+        return tool_get_assembly(function)
     elif name == "read_experiment_diff":
         iteration = inputs.get("iteration")
         if iteration is None:

--- a/loop.py
+++ b/loop.py
@@ -608,7 +608,7 @@ def format_history(experiments: list) -> str:
     near_misses = [
         e for e in experiments
         if not e.get("kept") and e.get("score_ns") and e.get("reason") == "regression"
-        and abs(e.get("improvement_pct", 0)) < 1.5
+        and abs(e.get("improvement_pct", 0)) < 0.5
     ][-3:]
     if near_misses:
         lines.append("\n=== NEAR-MISSES (close — consider combining or revisiting) ===")
@@ -633,7 +633,6 @@ def build_prompt(current_best_ns: float, experiments: list) -> str:
 
     return f"""You are a Rust performance engineer optimizing Plonky3's DFT/NTT implementation.
 
-## Hard Constraints
 {constraints}
 
 ## Current State
@@ -649,18 +648,18 @@ Benchmark command: `cargo bench -p p3-dft --features p3-dft/parallel --bench fft
 Make ONE focused, targeted optimization to the DFT implementation.
 
 Process:
-1. Read at most 2-3 files before writing — be targeted, not exhaustive
-2. Think about what is slow and why
+1. Identify a specific hot-path target
+2. Use `get_assembly` to verify what LLVM actually emits before assuming compiler behavior
 3. Make exactly one logical change using `write_file`
 4. End your response with: `IDEA: <one sentence describing the change and hypothesis>`
 
-**Value criterion**: The only measure of a good change is benchmark improvement in milliseconds. A 3-line change that saves 1% is better than a 1000-line rewrite that saves 0.5%. There is no reward for cleaner code, reduced complexity, or architectural elegance unless it moves the benchmark number.
+**Value criterion**: The only measure of a good change is benchmark improvement in milliseconds. A 3-line change that saves 1% is better than a 1000-line rewrite that saves 0.5%.
 
-**Slice large ideas**: If your idea requires changing more than ~50 lines, find the minimal targeted version first. A small near-miss on the right function is more valuable than a large rewrite — it gives the next iteration a precise target to build on. If a large idea is the only option, note it as IDEA: and write the smallest correct slice of it.
+**Slice large ideas**: If your idea requires changing more than ~50 lines, find the minimal targeted version first. A small near-miss on the right function is more valuable than a large rewrite.
 
-**Extend kept changes**: Look at the kept improvements in the history. Ask: is there a symmetric path, related function, or adjacent layer where the same technique applies? The most reliable improvements come from extending patterns that already work.
+**Extend kept changes**: Look at the kept improvements in the history. Ask: is there a symmetric path, related function, or adjacent layer where the same technique applies?
 
-**You must always make a change.** If your first idea seems risky, try a simpler targeted variant. If you feel stuck, consider: memory layout, twiddle factor access patterns, parallelism granularity, SIMD hints, loop restructuring, precomputation, special-casing boundary conditions. There is always something to try — do not give up.
+**You must always make a change.**
 """
 
 

--- a/loop.py
+++ b/loop.py
@@ -683,13 +683,27 @@ def run_agent_iteration(client: anthropic.Anthropic, prompt: str) -> tuple[bool,
     while True:
         for _attempt in range(5):
             try:
-                _stream_ctx = client.messages.stream(
+                with client.messages.stream(
                     model=MODEL,
                     max_tokens=MAX_TOKENS,
                     tools=TOOLS,
                     messages=messages,
-                )
-                break
+                ) as stream:
+                    had_text = False
+                    for event in stream:
+                        if event.type == "content_block_delta":
+                            delta = event.delta
+                            if hasattr(delta, "type") and delta.type == "text_delta" and delta.text:
+                                if not had_text:
+                                    print("  [agent thinking]", flush=True)
+                                    had_text = True
+                                print(delta.text, end="", flush=True)
+                    if had_text:
+                        print(flush=True)  # newline after streamed text
+                    response = stream.get_final_message()
+                    total_input_tokens  += response.usage.input_tokens
+                    total_output_tokens += response.usage.output_tokens
+                break  # stream completed successfully
             except anthropic.APIStatusError as _e:
                 if _e.status_code == 529 and _attempt < 4:
                     wait = 30 * (2 ** _attempt)
@@ -697,21 +711,6 @@ def run_agent_iteration(client: anthropic.Anthropic, prompt: str) -> tuple[bool,
                     time.sleep(wait)
                 else:
                     raise
-        with _stream_ctx as stream:
-            had_text = False
-            for event in stream:
-                if event.type == "content_block_delta":
-                    delta = event.delta
-                    if hasattr(delta, "type") and delta.type == "text_delta" and delta.text:
-                        if not had_text:
-                            print("  [agent thinking]", flush=True)
-                            had_text = True
-                        print(delta.text, end="", flush=True)
-            if had_text:
-                print(flush=True)  # newline after streamed text
-            response = stream.get_final_message()
-            total_input_tokens  += response.usage.input_tokens
-            total_output_tokens += response.usage.output_tokens
 
         # Scan text blocks for the IDEA: line and accumulate reasoning
         for block in response.content:

--- a/loop.py
+++ b/loop.py
@@ -705,9 +705,13 @@ def run_agent_iteration(client: anthropic.Anthropic, prompt: str) -> tuple[bool,
                     total_output_tokens += response.usage.output_tokens
                 break  # stream completed successfully
             except anthropic.APIStatusError as _e:
-                if _e.status_code == 529 and _attempt < 4:
+                is_overloaded = (
+                    _e.status_code == 529
+                    or "overloaded" in str(_e).lower()
+                )
+                if is_overloaded and _attempt < 4:
                     wait = 30 * (2 ** _attempt)
-                    print(f"[loop] Overloaded (529) — retrying in {wait}s (attempt {_attempt+1}/5)...", flush=True)
+                    print(f"[loop] Overloaded (status={_e.status_code}) — retrying in {wait}s (attempt {_attempt+1}/5)...", flush=True)
                     time.sleep(wait)
                 else:
                     raise

--- a/loop.py
+++ b/loop.py
@@ -978,7 +978,7 @@ def main():
             "baseline_ns": round(best_ns),
             "improvement_pct": 0.0,
             "agent_idea": idea,
-            "agent_thinking": thinking_summary,
+            "agent_thinking": "",  # omitted — full reasoning in terminal log
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
             "cost_usd": round(cost_usd, 6),

--- a/loop.py
+++ b/loop.py
@@ -767,13 +767,27 @@ def run_agent_iteration(client: anthropic.Anthropic, prompt: str) -> tuple[bool,
             messages.append({"role": "assistant", "content": response.content})
             tool_use_blocks = [b for b in response.content if hasattr(b, "type") and b.type == "tool_use"]
             budget_note = f"This is recovery attempt {recovery_count} of {MAX_RECOVERY}. You must write now or the iteration will be abandoned."
+
+            # Inject last reasoning block so agent continues its in-progress idea
+            # rather than pivoting to a safe fallback. Cap at 2000 chars — enough
+            # to capture the active idea without inflating the recovery message.
+            last_thinking = (all_text_blocks[-1] if all_text_blocks else "")[-2000:]
+            thinking_context = (
+                f"\n\nYour last reasoning before the cut-off:\n\"\"\"\n{last_thinking}\n\"\"\"\n\n"
+                "Continue from exactly where you left off. Do not explore new directions."
+            ) if last_thinking else ""
+
             if tool_use_blocks:
                 # Satisfy the API requirement: every tool_use needs a tool_result
                 recovery_content = [
                     {
                         "type": "tool_result",
                         "tool_use_id": b.id,
-                        "content": f"Response was cut off. {budget_note} Write your change now using write_file. End with: IDEA: <one sentence>",
+                        "content": (
+                            f"Response was cut off.{thinking_context}\n\n"
+                            f"{budget_note} Write your change now using write_file. "
+                            "End with: IDEA: <one sentence>"
+                        ),
                     }
                     for b in tool_use_blocks
                 ]
@@ -781,8 +795,8 @@ def run_agent_iteration(client: anthropic.Anthropic, prompt: str) -> tuple[bool,
                 recovery_content = [{
                     "type": "text",
                     "text": (
-                        f"Your response was cut off before you wrote any file. {budget_note} "
-                        "You have already read enough context. "
+                        f"Your response was cut off before you wrote any file.{thinking_context}\n\n"
+                        f"{budget_note} "
                         "Now write your change immediately using write_file — "
                         "be concise, no lengthy preamble. "
                         "End with: IDEA: <one sentence>"

--- a/loop.py
+++ b/loop.py
@@ -681,12 +681,23 @@ def run_agent_iteration(client: anthropic.Anthropic, prompt: str) -> tuple[bool,
     total_output_tokens = 0
 
     while True:
-        with client.messages.stream(
-            model=MODEL,
-            max_tokens=MAX_TOKENS,
-            tools=TOOLS,
-            messages=messages,
-        ) as stream:
+        for _attempt in range(5):
+            try:
+                _stream_ctx = client.messages.stream(
+                    model=MODEL,
+                    max_tokens=MAX_TOKENS,
+                    tools=TOOLS,
+                    messages=messages,
+                )
+                break
+            except anthropic.APIStatusError as _e:
+                if _e.status_code == 529 and _attempt < 4:
+                    wait = 30 * (2 ** _attempt)
+                    print(f"[loop] Overloaded (529) — retrying in {wait}s (attempt {_attempt+1}/5)...", flush=True)
+                    time.sleep(wait)
+                else:
+                    raise
+        with _stream_ctx as stream:
             had_text = False
             for event in stream:
                 if event.type == "content_block_delta":

--- a/setup.sh
+++ b/setup.sh
@@ -78,9 +78,15 @@ else
     echo "  AVX512: not detected (AVX2 path will be used)"
 fi
 
-# ── 6. First compile (populates cargo cache) ──────────────────────────────────
+# ── 6. Install cargo-show-asm (needed for get_assembly tool) ──────────────────
 echo ""
-echo "[6/6] Pre-compiling Plonky3 (first compile is slow — ~5min)..."
+echo "[6/7] Installing cargo-show-asm..."
+cargo install cargo-show-asm --quiet
+echo "  cargo-show-asm: $(cargo asm --version 2>/dev/null || echo 'installed')"
+
+# ── 7. First compile (populates cargo cache) ──────────────────────────────────
+echo ""
+echo "[7/7] Pre-compiling Plonky3 (first compile is slow — ~5min)..."
 cd "$SCRIPT_DIR/Plonky3"
 cargo build -p p3-dft --features p3-dft/parallel --release 2>&1 | tail -5
 

--- a/test_loop.py
+++ b/test_loop.py
@@ -172,7 +172,7 @@ class TestFormatHistory(unittest.TestCase):
 
     def test_near_misses_shown(self):
         import loop
-        exps = [self._make_exp(10, False, "regression", -0.8, "almost worked")]
+        exps = [self._make_exp(10, False, "regression", -0.3, "almost worked")]
         result = loop.format_history(exps)
         self.assertIn("NEAR-MISSES", result)
         self.assertIn("almost worked", result)


### PR DESCRIPTION
## Summary

Infrastructure improvements accumulated across Experiment 3 (20 iterations).

**Reliability fixes**
- Retry on Anthropic 529 overloaded errors with exponential backoff (30s→60s→120s→240s)
- Fix retry scope: wrap full stream block including SSE iteration, not just connection setup
- Fix retry match: overload mid-stream arrives as HTTP 200 with error in SSE body — match on error string not status code

**Agent tooling**
- Add `get_assembly` tool for compiler codegen verification — agent now checks assembly before submitting changes that rely on compiler behavior
- Inject last reasoning into recovery prompt to prevent idea pivot on token budget hit
- Lower near-miss threshold to 0.5% to reduce borderline keeps

**Agent guidance (CLAUDE.md)**
- Remove extension nudge ("look for symmetric paths") — caused 4/5 iters after a kept improvement to be wasted on extensions
- Remove exhausted promising ideas section
- Add Round 3 dead ends: backwards flag extensions, first-two-layers fusion confirmed, ALU reordering flat
- Add dead end classification methodology: 1 attempt insufficient, need 3+ with different implementations before declaring dead end

**Experiment logging**
- Suppress `agent_thinking` from jsonl (full reasoning preserved in terminal log)
- Add iter_20_report.md: full Experiment 3 results, cost/token stats, behavioral analysis

## Notes

Benchmark results pending — running comprehensive multi-branch validation overnight before publishing numbers.
