### PR TITLE
chore: add missing queue shard subdirs in brain_example

### DIFF
--- a/brain_example/queue/active/.gitkeep
+++ b/brain_example/queue/active/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder. Per-experiment <id>.json entries land here. See brain_example/queue/README.md.

--- a/brain_example/queue/claimed/.gitkeep
+++ b/brain_example/queue/claimed/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder. Per-experiment <id>.json entries land here. See brain_example/queue/README.md.

--- a/brain_example/queue/done/.gitkeep
+++ b/brain_example/queue/done/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder. Per-experiment <id>.json entries land here. See brain_example/queue/README.md.

--- a/brain_example/queue/killed/.gitkeep
+++ b/brain_example/queue/killed/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder. Per-experiment <id>.json entries land here. See brain_example/queue/README.md.

--- a/brain_example/queue/merged/.gitkeep
+++ b/brain_example/queue/merged/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder. Per-experiment <id>.json entries land here. See brain_example/queue/README.md.

--- a/brain_example/queue/needs-decision/.gitkeep
+++ b/brain_example/queue/needs-decision/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder. Per-experiment <id>.json entries land here. See brain_example/queue/README.md.

--- a/brain_example/queue/pending/.gitkeep
+++ b/brain_example/queue/pending/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder. Per-experiment <id>.json entries land here. See brain_example/queue/README.md.


### PR DESCRIPTION
## Summary

PR #58 added `brain_example/queue/README.md` but missed the actual shard subdirectories. A fork copying `brain_example/queue/` to `brain/queue/` would land with no destinations to drop entries into.

Adds 7 subdirs, each with a `.gitkeep` placeholder:

- `pending/` — awaiting dispatch
- `claimed/` — coordinator about to launch
- `active/` — running on an executor
- `done/` — stop criterion hit, pr_body.md drafted
- `merged/` — PR merged upstream
- `killed/` — PR closed without merge OR experiment retired
- `needs-decision/` — coordinator escalation to brain

Matches the live `brain/queue/` shape on the operating fork.

## Test plan

- [x] CI green
- [x] Verify `tree brain_example/queue/` shows all 7 subdirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)