### PR TITLE
feat(pw4_2): add M4-M macOS variant for parallel dispatch

### DIFF
--- a/experiment_logs/leanMultisig/optimization/pw4_2_poseidon_m4m_2026-05-13/context.md
+++ b/experiment_logs/leanMultisig/optimization/pw4_2_poseidon_m4m_2026-05-13/context.md
@@ -1,0 +1,67 @@
+# pw4_2-m4m — Context (read once at session start, do not re-read per iter)
+
+This file is what prior experiments (pw3, pw4) found. Treat it as ground truth — do not re-attempt confirmed dead-ends, do not re-claim confirmed wins, do not re-litigate methodology that's already settled.
+
+## Starting state
+
+pw4 already optimized scalar-binding on the SIMD `compress_mut` path on Hetzner Zen 4 AVX-512 (three commits live on the dev branch `myfork:dev/poseidon-scalar-bind-3-keep-2026-05-13`, not yet on `origin/main`). Those wins were AVX-512-codegen-specific; whether they port to NEON on Apple Silicon is open. pw4_2-m4m starts from `origin/main` — attack different surfaces, but a scalar-binding sub-investigation in `compress_mut` IS in scope here (different ISA, different register file, the conclusion may be different than on Hetzner).
+
+A sibling experiment `pw4_2-2026-05-13` runs in parallel on Hetzner Zen 4 AVX-512. You do not coordinate with it; each branch is independent. Cross-platform delta = valuable signal at the end (some optimizations win on both architectures, some are silicon-specific).
+
+## Unattempted-from-pw4 surfaces (candidate pool input)
+
+pw4 left these untouched. **The Candidate Pool in program.md is selected from this list (3-5 surfaces).**
+
+| Surface | Predicted Δ% | Type | Notes |
+|---|---|---|---|
+| Tier 1 #2 chain-spanning delayed Montgomery | +3-6% | structural | Keep state[0] in wider accumulator ACROSS partial rounds, reduce only when bound forces. **NOT the pw4-10 single-rc-add range relaxation — that was a nibble, not the real chain-spanning idea.** Constraint: bound `S_max^3 · |MDS_row|_1` < accumulator width per chain length. Derive max chain length explicitly. |
+| Tier 1 #4 MDS coefficient re-search ≤4-magnitude | +3-7% | structural | Current MDS uses 67, 63, 101 (forces full mul-port use). A circulant column with entries ≤ 4 maps multiplies into shifts+adds. **Cryptanalysis-gated**: if you produce a candidate matrix that proves the MDS property + branch number ≥ 17 over KoalaBear, log the matrix + the proof sketch in `iters.tsv` under `status=cryptanalysis-pending`. Move on to the next candidate; do NOT block the loop or ship this iter as a keep. The cryptanalysis review happens out-of-band, outside your session. |
+| Tier 2 Jagged-PCS leaf packing | +4-8% uniform | structural | Multi-poly batched commits sharing leaves. SP1 Hypercube claims 5× on this lever. Touches `stacked_pcs.rs` + Merkle leaf assembly. pw4-27 tried a related layout-padding tweak (sub-gate); the proper Jagged-PCS work is more ambitious. |
+| Tier 2 WHIR tree-pruning for shared Merkle paths | TBD | structural | Cache sibling hashes during open when many query indices share Merkle ancestors. Pure encoding optimization, no security impact. Unattempted entirely. |
+| Sumcheck ⊗ eq-MLE kernel fusion (Tier 3 from pw4) | TBD | structural | `mt_sumcheck` (12%) + `mt_poly` (6%) + `sub_protocols` (9%) = 27% Hetzner, adjacent to Poseidon's 27%. **Conditional trigger:** only if first Tier-1 attempt lands ≥10% cumulative AND Poseidon share drops below sumcheck/eq-MLE in re-profile. |
+
+## Inspiration repos (allowed, in-loop reading)
+
+`origin/main` source only — **NO `git log`** on these repos.
+
+- Plonky3 (`~/zk-autoresearch/Plonky3`) — Poseidon1/Poseidon2 implementations, packed-field arithmetic, FRI. Use the `neon/` and scalar paths; the `avx512/` paths in Plonky3 are not relevant to this hardware.
+- SP1 (`~/zk-autoresearch/sp1`) — Hypercube / Jagged-PCS reference; sumcheck batching patterns
+- Jolt (`~/zk-autoresearch/jolt`) — Dory commitments; alternative PCS shapes
+
+All three are present at the cited paths on the executor (verified). Halo2 is NOT cloned — if you want to look at lookup-argument patterns, the Plonky3 logUp implementation is the in-tree reference.
+
+## Verdict.md structured header (write at stop time)
+
+When stop criterion trips, the verdict.md MUST start with this YAML header before any prose:
+
+```yaml
+---
+experiment: pw4_2-poseidon
+start_commit: c868330c
+final_commit: <SHA>
+cumulative_pct: <number, e.g., -3.42>
+cumulative_p_value: <number>
+keeps:
+  - hypothesis_id: h1
+    iter_id: pw4_2-N
+    delta_pct: <number>
+    surface: <one-line description>
+discards: <count>
+orphans: <count, with delta_pcts>
+dead_ends_confirmed:
+  - <one-line description>
+methodology_notes: <free-form prose, but minimal>
+---
+```
+
+Body below the header is free-form prose.
+
+## Two attempts per hypothesis — examples of when to retry
+
+**Retry warranted (attempt 2):**
+- Hypothesis: "scalar-bind these 5 vars should let codegen keep them in ZMM registers". Attempt 1: codegen still spills due to lifetime overlap. Diagnostic (perf annotate) shows spills on var 3 and var 5. Attempt 2: reorder lifetimes via explicit blocks, recompile. Different mechanism, same hypothesis.
+
+**Retry NOT warranted (declare dead-end):**
+- Hypothesis: "this rayon nesting cleanup wins on prove_loop too". Attempt 1: −0.08%. Diagnostic shows it's a different workload's bottleneck. The hypothesis is class-mismatched; retrying won't fix that.
+
+The diagnostic step is what distinguishes the two. Run perf + read disassembly + reason about WHY. Don't skip.

--- a/experiment_logs/leanMultisig/optimization/pw4_2_poseidon_m4m_2026-05-13/profiling.md
+++ b/experiment_logs/leanMultisig/optimization/pw4_2_poseidon_m4m_2026-05-13/profiling.md
@@ -1,0 +1,139 @@
+# pw4_2-m4m — Initial profiling (read once at session start)
+
+Source: distilled from `experiment_logs/leanMultisig/profiling/concluded/profiling_macos_m4m32_pr216_2026-05-12/program.md` and its `summary_note.md` + `phase_2_hot_symbols.md` (the parent profiling experiment on this exact hardware). Raw phase outputs from that experiment live in its gitignored `report/` subdir on brain — NOT synced to this executor. The distilled numbers in this file are the canonical reference for pw4_2-m4m.
+
+**This profile decays after your first big keep (cumulative ≥ -3%).** When that happens, re-profile via the cheatsheet below; the fresh profile supersedes this file as your hot-symbol reference. Don't keep planning iterations from a stale picture.
+
+## Conditions
+- Scaleway M4-M: Apple **M4 base** (Mac16,10) — NOT M4 Pro despite SKU naming.
+- 10 cores: 4 P-core + 6 E-core, no SMT.
+- 32 GiB RAM (LPDDR5X, ~120 GB/s — NOT the ~273 GB/s of M4 Pro).
+- macOS Sequoia 15.6.1 (build 24G90), Darwin 24.6.0 arm64.
+- 16 KiB native page. NEON 128-bit. ARMv9 SME (unused by current Plonky3).
+- Workload: `prove_loop 3` (3 proofs, 1550 sigs, log_inv_rate=1, fat LTO, zkalloc global)
+- Baseline: `origin/main @ c868330c` (PR #216 already integrated into main)
+- Capture method: `sample <pid> 10` (1 ms interval) + `xcrun xctrace record --template 'Time Profiler'` + `sudo powermetrics --samplers cpu_power`. NO `perf` available.
+
+## Top-line (parallel, 10-thread rayon pool, 3 proofs, on origin/main)
+
+| Metric | Value |
+|---|---:|
+| 5-proof wall (warm) `/usr/bin/time real` | ~2.21 s per warm proof |
+| **Warm-proof wall (main)** | **2.206 s** |
+| Sample budget per profile | ~60k thread-samples (10 s × 11 threads) |
+| Inclusive Poseidon (of-CPU-bound, sample) | **58.23%** (main) |
+| `__psynch_cvwait` (rayon worker idle) | **18.54% self-time** |
+| Rayon plumbing (bridge/helper) | 11.11% self-time |
+| P/E heterogeneity tax (theoretical / effective) | 30.1% / 45% — P-core runs ~1.62× faster than E-core |
+| P/E topology | 4 P-core + 6 E-core, no SMT |
+
+**Workload classification:** Poseidon-dominant CPU-bound. The TWO biggest CPU sinks are (1) the SIMD permutation and (2) **rayon worker idle on barrier** — at 18.54% of self-time, `__psynch_cvwait` is essentially "P-cores waiting for E-cores to finish their share of work." Memory bandwidth is constrained vs M4 Pro (120 vs 273 GB/s) but not the dominant bottleneck.
+
+Cross-platform reference (PR #216 paired Δ wall):
+- Hetzner Zen 4 64 GiB: −5.58%
+- M2 Asahi Linux 16 GiB: −6.64%
+- M2 Pro macOS 16 GiB: −5.05% ± 0.89
+- **M4 macOS 32 GiB (this hardware)**: **−5.23% ± 0.53**
+
+## Top inclusive call-graph paths (sample, 10 s window, main)
+
+| Self % | Symbol |
+|---:|---|
+| **23.78%** | `Poseidon1KoalaBear16::compress_mut` (primary hash variant — entered via `mt_merkle::commit` / `poseidon_compress_slice`) |
+| **18.54%** | `__psynch_cvwait` (rayon worker idle on conditional variable) |
+| 11.11% | `rayon::bridge_producer_consumer::helper` |
+| 4.54% | `lean_vm::tables::poseidon_16::eval_2_full_rounds_16` (AIR-side first two rounds) |
+| 3.80% | `Poseidon1KoalaBear16::compress_mut` (second variant) |
+| 2.61% | `mt_poly::eq_mle::eval_eq_with_packed_output` |
+| 1.91% | `Poseidon1KoalaBear16::permute_mut` |
+| 1.89% | `ConstraintFolderPacked::...` (AIR builder) |
+| 1.65% | `mt_sumcheck::fold_and_compute_product_sumcheck_polynomial` |
+| 1.55% | `Poseidon16Precompile::eval` (AIR) |
+| 1.36% | `lean_vm::tables::poseidon_16::eval_last_2_full_rounds_16` |
+
+**Poseidon-inclusive total ≈ 58.23% of CPU-bound cycles.** The two biggest non-Poseidon costs are rayon idle wait (18.54%) and rayon plumbing (11.11%) — together ~30% of CPU-bound is parallelism overhead.
+
+## Bottleneck-shape map (M4-M specific — DIFFERENT from Hetzner!)
+
+| Lever class | Effect on M4-M parallel | Notes |
+|---|---|---|
+| Mul-count reduction (algorithmic) | strong win (attacks 23.78% compress_mut self) | Same as Hetzner |
+| Permutation-count reduction (sponge RATE, Merkle topology, leaf packing) | strong win | Same as Hetzner |
+| **P/E core affinity (rayon ThreadPool with core_affinity)** | **POTENTIALLY HUGE (8-15% predicted) — not yet attempted** | M4-M-specific; pin Poseidon work to P-cores |
+| **Reducing rayon barrier waits (chunk sizing, work-stealing tuning)** | **medium-strong (cvwait is 18.54% — 1 pp reduction = 1.7% wall)** | M4-M-specific; not in Hetzner pool |
+| Mul-port-relief in `compress_mut` (register-pressure, scalar binding) | uncertain — M4 has different register file + NEON ≠ AVX-512 | DIFFERENT from Hetzner (Hetzner has 32 ZMM, M4 has 32 NEON Q-regs but different latencies) |
+| DRAM-bandwidth cache-blocking | medium win (120 GB/s ceiling) | Less effective than on Hetzner (single CCD vs M4's unified bandwidth) |
+| `MADV_HUGEPAGE` on zk-alloc slabs | NULL on macOS (no transparent huge pages) | DIFFERENT |
+| Source-level wrappers / inline hints | NULL (LTO neutralizes) | Same |
+
+**Key insight specific to M4-M:** the 4P+6E heterogeneity tax dominates parallelism efficiency. Any optimization that reduces TOTAL CPU-bound work helps, but you also have the unique M4 lever of **shifting which cores execute Poseidon** (P-cores at ~1.62× E-core speed). The Hetzner sibling agent does NOT have this lever; it has homogeneous 8c/16t SMT.
+
+## Profiling cheatsheet (commands the agent should use freely)
+
+macOS does NOT have `perf`. Use the macOS stack instead. **Most commands need `sudo`** — passwordless sudo is configured.
+
+```bash
+# Build with debug info for symbol-level profiling
+CARGO_PROFILE_RELEASE_DEBUG=true RUSTFLAGS="-C target-cpu=native" \
+  cargo build --release --bin prove_loop --features zkalloc_global
+
+# Discard page cache between paired runs (important on macOS)
+sudo purge
+
+# Sample (1 ms interval, single-process) — primary self-time tool
+./target/release/prove_loop 3 &
+PID=$!
+sleep 2  # skip setup
+sudo sample $PID 10 -file /tmp/sample.txt
+wait $PID
+# Output: 38 MB call-tree. grep for hot symbols:
+grep -E '^\s+[0-9]+\s+Poseidon|compress_mut|cvwait' /tmp/sample.txt | head -30
+
+# xctrace Time Profiler (kernel-thread accurate, all threads)
+xcrun xctrace record --template 'Time Profiler' \
+  --launch -- ./target/release/prove_loop 3 \
+  --output /tmp/run.trace
+xcrun xctrace export --input /tmp/run.trace \
+  --xpath '/trace-toc/run[@number="1"]/data/table[@schema="time-sample"]' \
+  > /tmp/run.xml  # parse with a helper
+
+# dtrace for syscall / thread-state breakdown
+sudo dtrace -n 'profile-997 /pid == <pid>/ { @[ustack()] = count(); }' &
+DPID=$!
+./target/release/prove_loop 3
+kill $DPID
+
+# powermetrics for P/E core breakdown (residency, freq, package power)
+sudo powermetrics --samplers cpu_power -i 1000 -n 30 > /tmp/pm.txt
+# Look at: P-core vs E-core %active, freq histogram, "CPU x active residency"
+
+# Serial vs parallel comparison
+RAYON_NUM_THREADS=1 ./target/release/prove_loop 3
+RAYON_NUM_THREADS=10 ./target/release/prove_loop 3
+
+# Per-core thread placement check (which threads on P vs E)
+sudo dtrace -n 'mach_kernel:thread_dispatch:thread_dispatch {
+  @[execname, tid, cpu] = count(); }' > /tmp/cpu_placement.txt &
+./target/release/prove_loop 3
+# Map to P (CPU 0-3) vs E (CPU 4-9) cores
+
+# Disassemble a release binary symbol
+objdump -d --no-show-raw-insn --no-leading-addr target/release/prove_loop \
+  | awk '/<.*Poseidon1KoalaBear16.*compress_mut.*>:/,/^$/' | head -200
+```
+
+## When to re-profile
+
+**Trigger re-profile when ANY of:**
+- A keep lands with cumulative ≥ -3% vs origin/main
+- Hot symbol distribution has materially shifted (e.g., `compress_mut` share drops below 18%, or `cvwait` drops below 14%)
+- You're 5+ iterations in on the same hot symbol with no keep — re-profile to confirm the symbol is still the right target
+
+After re-profile: write `report/profiling_after_iter_N.md` (gitignored in report/) with the new distribution. Reference THAT file, not this one, going forward.
+
+## What's NOT in this file (intentionally)
+
+- Per-line `sample` dumps — too much detail; agent re-runs them per-hypothesis with the cheatsheet
+- Allocator-pressure analysis — already factored into zk-alloc enablement; no further leverage here. On macOS, Mach-VM lazy backing handles slab over-commitment cleanly.
+
+If you need any of the above, the full profiling baseline experiment's `program.md` is at `experiment_logs/leanMultisig/profiling/concluded/profiling_macos_m4m32_pr216_2026-05-12/program.md` (raw phase outputs are NOT on the executor — they live on brain only). If you need fresh per-line data, re-run the cheatsheet commands above against the current binary.

--- a/experiment_logs/leanMultisig/optimization/pw4_2_poseidon_m4m_2026-05-13/program.md
+++ b/experiment_logs/leanMultisig/optimization/pw4_2_poseidon_m4m_2026-05-13/program.md
@@ -1,0 +1,206 @@
+# pw4_2-m4m — Poseidon Performance Research on Apple M4 macOS (high-ambition successor to pw4)
+
+**READ THIS FILE AT THE START OF EVERY ITERATION'S PHASE 1. NOT OPTIONAL.**
+
+Companion files (read ONCE at session start, do not re-read per iter):
+- `context.md` — what prior experiments (pw3, pw4) found; dead-ends; methodology lessons
+- `profiling.md` — initial profiling baseline (becomes stale after first keep — re-profile then)
+
+## Role
+
+You are a cryptographic researcher specializing in zk-prover performance. You bring algebraic intuition (Poseidon round structure, MDS branch-number invariants, sumcheck folding, FRI commit cost) AND microarchitecture intuition (Apple Silicon NEON 128-bit packed-field arithmetic, P/E heterogeneous-core scheduling, Mach-VM lazy backing, macOS rayon idle-wait costs). You read source code and disassembly with equal facility.
+
+This experiment is high-ambition. You attack structural surfaces with predicted wins ≥1% wall-clock, not knob-turning. Iterations are slow and deep (target 30+ min/iter): profile → disassembly → mechanism analysis → register-budget computation → hypothesis → implementation → gate → diagnostic on discard.
+
+You operate autonomously. You commit, gate, decide.
+
+## Hardware
+Scaleway M4-M (Apple **M4** base, Mac16,10 — NOT M4 Pro despite the SKU naming. ~120 GB/s LPDDR5X memory bandwidth). 10 cores: 4 P-core + 6 E-core, no SMT, 32 GiB RAM. macOS Sequoia 15.6.1, Darwin 24.6.0 arm64. 16 KiB native page. NEON 128-bit only. NO `perf` — use `sample`, `xcrun xctrace`, `dtrace`, `powermetrics`.
+
+Branch `pw4_2-m4m-2026-05-13` from `origin/main` at `c868330c`. (The Hetzner sibling experiment `pw4_2-2026-05-13` runs in parallel on Zen 4 AVX-512; you are NOT aware of its progress and do NOT coordinate with it. Each branch is independent.)
+
+## HARD RULES (also in repo CLAUDE.md — both apply)
+
+1. **No microoptimizations.** Predicted Δ% at hypothesize time must be **≥ 1.5%** (gate threshold is 1.0%; the 50% margin gives reliable discrimination above noise σ=0.51%). Aim high — small-scale optimizations are not this experiment's target. Single number, not a range. If your own prediction is sub-1.5%, re-scope or skip.
+2. **No cherry-picks.** Off-main branches (any repo, any fork) are forbidden as idea sources. `git log` / `git show` / `git diff` against refs other than `origin/main` and `pw4_2-m4m-2026-05-13` is banned. Local `git diff HEAD~1` on the experiment branch is fine. Violations terminate the session.
+3. **No mining inspiration repos.** Plonky3 / Jolt / SP1 source on their `origin/main` IS allowed for algorithmic-pattern study. Their `git log` is NOT.
+4. **Magnitude class definitions are strict.** structural = (≥80 LoC) AND (multi-file OR new public API). Both LoC and a structural axis must be satisfied. Otherwise medium. Agent cannot self-classify dishonestly.
+5. **Per-keep proof-size sanity (inline, no full test suite).** Before iter 1, seed the baseline once on `origin/main`:
+   ```bash
+   cd ~/zk-autoresearch/harness/leanmultisig/bench && \
+     RUSTFLAGS="-C target-cpu=native" cargo build --release --bin proof_size_check && \
+     ./target/release/proof_size_check | tee /tmp/lm_proof_size_baseline.txt
+   ```
+   After every keep, build + run `proof_size_check` on the kept commit, compare bytes vs baseline. If `|Δ| > 1%`, revert the commit (it shipped an unintentional proof-size regression). The full multi-suite verify (`verify_post_experiment.sh`) is human-triggered post-experiment, NOT per-iter.
+
+## Iteration cycle
+
+```
+Phase 1: Hypothesize (DEEP, this is where slow iteration earns its keep)
+  - Cite specific profiling data, disassembly, dependency-chain analysis
+  - State predicted Δ% (must be ≥ 1.5%, single number) with explicit mechanism
+  - State magnitude class up-front (medium or structural)
+  - State kill condition: what would tell you this hypothesis is wrong
+    even before measuring?
+  - Re-read this program.md (it's mandatory; the candidate pool and
+    rules anchor the next decision)
+  - Inspiration repo review:
+      0-2 consecutive zero-keeps → optional
+      3+ consecutive zero-keeps → MANDATORY before Phase 2
+    (see Inspiration sources section below)
+
+Phase 2: Implement (attempt #1 of this hypothesis)
+  - Single change, commit on pw4_2-m4m-2026-05-13 (NEVER main)
+  - Commit subject MUST start with [medium] or [structural] tag
+
+Phase 3: Gate
+  - bash ~/zk-autoresearch/harness/leanmultisig/scripts/eval_paired.sh
+  - Auto-chain handles cumulative + Criterion ship-gate on KEEP
+  - KEEP (fast-tier exit 0 + ship-gate exit 0) → Phase 5 (pivot)
+  - KEEP (fast-tier) but ship-gate exit 1 (REGRESS) or exit 2 (COULD-NOT-MEASURE):
+      Run `bash ~/zk-autoresearch/harness/leanmultisig/scripts/eval_revert_ab.sh`.
+      If A/B reproduces ≥ MIN_REPRODUCE_FRACTION (config.env:45 = 0.5) → KEEP;
+      else REVERT. Log the ship-gate-conflict status in rationale column.
+  - DISCARD → Phase 4 (diagnostic)
+  - Three consecutive eval exit 2 (infra error) in a row → pause for human
+    intervention; do NOT count toward 12-zero-keep counter. Run `df -h /tmp /home`
+    at every iter start to catch disk-fill early.
+
+Phase 4: Diagnostic (only on discard, NOT optional)
+  - Re-run with `perf record -F 997` + `perf report` on candidate binary
+  - Compare cycle counts / instruction mix on the changed function
+  - Classify why:
+      (a) hypothesis-wrong   → log dead-end, Phase 5 (pivot, different surface)
+      (b) implementation-bug → fix + retry as attempt #2 (max 2 attempts/hypothesis)
+      (c) compiler-quirk     → reframe (intrinsics, layout, alignment); retry as attempt #2.
+                                MUST cite disassembly-diff evidence (objdump pre/post)
+                                in the rationale or downgrade to (a).
+      (d) measurement-edge   → real but sub-gate. Requires |measured| ≥ 0.5% AND
+                                p_value < 0.10. Log as ORPHAN in iters.tsv
+                                (status=orphan), then Phase 5. Below that floor,
+                                classify (a) hypothesis-wrong instead.
+      (e) env-confound       → drift abort fired, thermal anomaly, neighbor load.
+                                Retry without consuming an attempt. Log env metadata.
+  - Max 2 attempts per hypothesis. After 2 failed attempts: dead-end, Phase 5.
+  - Orphans cap: 3 per session. Beyond 3, the orphan-accumulation pattern is its
+    own structural hypothesis — surface and address explicitly.
+
+Phase 5: Pivot
+  - If KEEP: re-profile (mandatory if cumulative ≥ -3%); update bottleneck mental model
+  - State which Candidate Pool entry next, and why it ranks above the unattempted ones
+  - Pending orphans MUST be bundled with the next compatible medium/structural;
+    "compatible" = orphan's commit and next iter's commit touch overlapping files
+    AND have independent mechanisms (different lines, no logical interaction).
+    No bundle = log explicit reason in the next iter's rationale.
+```
+
+## Inspiration sources
+
+Valid inputs to hypothesis formation, in addition to your own profiling + code reading:
+
+- **Inspiration repos**: `origin/main` source of Plonky3 (`~/zk-autoresearch/Plonky3`), SP1 (`~/zk-autoresearch/sp1`), Jolt (`~/zk-autoresearch/jolt`), Halo2. Read their source for algorithmic-pattern study. **Their `git log` is banned per HARD RULE 3** — only `origin/main` source.
+
+Citing an inspiration source in Phase 1 commit body is welcome — it makes the hypothesis legible.
+
+## Candidate Pool (4 broad targets, EV-ranked; 5th slot intentionally open)
+
+*The pool below is starting context, curated by brain pre-dispatch. You may attempt other novel surfaces if profiling justifies AND you explicitly rank against this pool. After Target A lands, re-profile reshapes priorities — that's when the 5th candidate gets surfaced organically.*
+
+*Each broad target has 2-3 suggestion angles. You pick the angle within a target; you must justify if you skip a higher-EV target for a lower one.*
+
+### Broad Target A: x2 batched Poseidon1 permutation (state-interleaving)
+
+- **Profile anchor:** `compress_mut` 22.28% self + `permute_simd::mds_fft` 7.99% inclusive + `Poseidon16Precompile::eval` (AIR side, `lean_vm::tables::poseidon_16`) ~5%. Total Poseidon-permutation surface ≥ 27%.
+- **Paper anchor:** Bagad et al., *Packed Sumcheck* (eprint 2025/719) — packing multiple independent instances into one SIMD register, principle transferred to permutation.
+- **Predicted Δ% range:** +3-6%. **Magnitude class:** structural.
+- **Already-shipped check:** `permute_simd` body at `crates/backend/koala-bear/src/poseidon1_koalabear_16.rs:945-1032` does intra-permutation ILP only; no `permute_state_x2` / `compress_mut_x2` / two-independent-permutation interleaving exists. `crates/backend/symetric/src/merkle.rs:50-90` `compress_layer` processes 16 packed lanes per call but each lane is one permutation; consecutive permutations are serial in the dep graph. **Verified absent.**
+- **Why high EV:** stack-spill hot line `vmovdqa64 %zmm3, 0x780(%rsp,%rsi,1)` at 2.22% says one permutation already exceeds the 32 ZMM register budget. Two interleaved permutations expose more independent work to the back-end scheduler at no net register cost — second permutation's idle state fills issue slots between dep-chained S-box/MDS of the first. Mul-port-bound means we win iff we issue more independent mul-port ops per cycle; this attacks that directly.
+
+**Suggestions (pick one to start):**
+- **A.1:** `permute_state_x2` on the SIMD path — accept `&mut [PackedKB; 16], &mut [PackedKB; 16]` and run both permutations interleaved across 16+20+4 rounds, sharing round-constant fetches; pre-issue second instance's S-box while first's MDS is in flight. Adapt `compress_layer` to consume pairs.
+- **A.2:** Single-permutation re-scheduling to keep ≤24 ZMM live — split partial-round inner loop so `split.s0` updates and `s_hi_mut` rank-1 updates use separate sub-functions with explicit drop-points; reduce simultaneously-live `packed_sparse_first_row[r]` + `packed_sparse_v[r]` references. Targets the 2.22% spill directly.
+- **A.3:** `mds_fft` constant-folding — push the `lambda16[i]` diagonal multiplies INTO the final layer of the inner FFT, fusing 16 free-standing muls with twiddle-mul chains. Same end values, fewer dependent issue slots.
+
+*Note on chain-spanning delayed Montgomery (a tempting 4th angle for this target): the cube in `sbox` blows u128 after one extra round (`2^93 × 2^10 = 2^103` per step; two steps = 2^206). Only the s_hi rank-1 update is delay-reducible, and that sub-mechanism overlaps with A.2. Don't spend an iter rediscovering this bound.*
+
+### Broad Target C: First-layer sponge → compression mode for ≥2-leaf widths
+
+- **Profile anchor:** `mt_whir::merkle::first_digest_layer + symetric::hash_slice` ~5% combined. Sponge mode runs ≥2 `compress_mut` calls per leaf (`crates/backend/symetric/src/sponge.rs:17-25`); if leaf base-width ≤ 8 (one RATE chunk), padding + extra compress calls can be eliminated.
+- **Paper anchor:** Poseidon2 compression-vs-sponge mode for Merkle trees (1.5-2× over sponge for internal hashing). Principle generalizes to Poseidon1.
+- **Predicted Δ% range:** +1.5-3%. **Magnitude class:** medium.
+- **Already-shipped check:** `first_digest_layer` at `crates/whir/src/merkle.rs:215-248` uses `hash_rtl_iter` (sponge) unconditionally regardless of whether the leaf fits one RATE chunk. `precompute_zero_suffix_state` (L67-78) covers multi-chunk-with-trailing-zeros but **still uses sponge absorption** for live chunks. The `compress` helper at `crates/backend/symetric/src/compression.rs:5-15` exists but is only called for **inner** Merkle levels (`merkle.rs:77, 86, 116`), never for the first WHIR Merkle layer. **Verified absent for first-layer.**
+- **Why high EV:** internal Merkle layers already use `compress`; only the first WHIR Merkle layer (one of the hot symbols) still pays sponge overhead. Fix: dispatch `compress` directly when `effective_base_width ≤ RATE` and leaf fits in the WIDTH−RATE capacity slot. Profile-anchored, cheap, structurally clean.
+
+**Suggestions:**
+- **C.1:** First-layer fast path calling `crate::compress(comp, [hi_half, lo_half])` directly when leaf base-width ≤ 8, bypassing `hash_rtl_iter`. Touches `first_digest_layer` + `first_digest_layer_with_initial_state` only.
+- **C.2:** Eliminate the leaf-pad-to-`full_leaf_base_width` step when `effective_base_width == full_leaf_base_width` — currently `WhirMerkleTree::open` (`crates/whir/src/merkle.rs:205-211`) unconditionally `resize`s. Only valuable when WHIR config picks `effective < full`. Profile whether this branch fires often enough to clear the gate; sub-gate alone, viable as a bundle with C.1.
+
+### Broad Target D: BDDT eq-MLE residual lift in sumcheck
+
+- **Profile anchor:** `mt_sumcheck::fold_and_compute_product_sumcheck_polynomial` 4.30% + 3.44% (two closures); `mt_poly::eq_mle::eval_eq_with_packed_output` 4.28%; `sub_protocols::quotient_gkr` 9%. Sumcheck/eq cluster total 27%.
+- **Paper anchor:** BDDT, *Small-Value Eq-Poly Sumcheck* (eprint 2025/1117). **Research-vs-profile tension flagged honestly:** paper headlines 2-3×, but the small-value/delayed-reduction sub-trick is substantially already adopted in this tree (`crates/backend/sumcheck/src/product_computation.rs:172-199` uses `[u128;D] / [i128;D]` accumulators with chunk_size=1024 batching). Honest residual lift after subtracting already-adopted base+ext path: +2-4%.
+- **Predicted Δ% range:** +2-4%. **Magnitude class:** structural.
+- **Already-shipped check:** `compute_product_sumcheck_polynomial_base_ext_packed` (`product_computation.rs:172-199`) has the small-value delayed reduction. The **eq-factorization** trick is NOT in: `compute_eval_eq_base_packed_batched` (`crates/backend/poly/src/eq_mle.rs:372-430`, L415 par_iter) **rebuilds the full eq tile per call** rather than incrementally maintaining eq across sumcheck rounds. **Verified residual surface exists** in the eq-batching path, not in the product-sumcheck kernel itself.
+- **Why high EV but ranked below A/C:** large profile surface (27%) but the headline-impactful sub-trick is already in. The remaining lift is real but smaller than paper claims for our setup. Listed because the surface size still supports ≥2% even after de-rating.
+
+**Suggestions:**
+- **D.1:** Incremental eq-evaluation in `add_new_equality` / `add_new_base_equality` (`crates/whir/src/open.rs:336-381`) — currently rebuilds eq-poly per `points` slice via `compute_eval_eq_packed`. Maintain a persistent eq-vector across statements; update incrementally using folding randomness already in `round_state.randomness_vec`.
+- **D.2:** Toom-Cook product-folding for per-round univariate polynomial in `fold_and_compute_product_sumcheck_polynomial` — round-poly is sampled at {0, 2} with c1 derived from `sum − 2·c0 − c2` (`product_computation.rs:301`, inside the `fold_and_compute_*` body starting at L242; same pattern also appears at L166 and L237 inside the non-fold siblings — your edit target is L301 specifically). Sample at {0, ±1, ∞} for higher-degree variants, saves base-field muls. Targets the two-closure 7.74% cluster. Paper anchor: Dao-Thaler, eprint 2024/1210.
+
+### Broad Target E: Cryptanalysis-gated MDS coefficient re-search (small-entry circulant)
+
+- **Profile anchor:** `compress_mut` 22.28% self. Current MDS circulant column at `crates/backend/koala-bear/src/poseidon1_koalabear_16.rs:22` is `[1, 3, 13, 22, 67, 2, 15, 63, 101, 1, 2, 17, 11, 1, 51, 1]`. Entries 67, 101, 63 force full mul-port use during MDS application; small-entry alternatives map muls into shifts+adds.
+- **Paper anchor:** Anemoi/Rescue/Tip5 family design-space (small-entry MDS principle) + Vision-Mark32 KoalaBear-native designs.
+- **Predicted Δ% range:** +3-7% **IF cryptanalysis approves**. **Magnitude class:** structural.
+- **Already-shipped check:** column has max entry 101, exceeds 4. Plonky3 Poseidon1 KoalaBear default ported verbatim; mul-port-attacking re-search has not happened in this tree. **Verified absent.**
+- **Why ranked last:** highest theoretical upside but **cryptanalysis-gated** per `context.md:16`. Per the gating: if you produce a candidate matrix that proves MDS property + branch number ≥ 17 over KoalaBear, log under `status=cryptanalysis-pending` in `iters.tsv` and **move on without shipping**. Listed for completeness — right second-or-third attempt while cryptanalysis is async; NOT the right first attempt (defers the gain by weeks).
+
+**Suggestions:**
+- **E.1:** Algorithmic search for circulant 16×16 MDS over KoalaBear with all entries ∈ {-4,…,4} (mul-by-≤4 = ≤2 SIMD adds), satisfying MDS property (all 1×1 to 16×16 minors non-singular over Fp). Verify branch number = 17 via brute force on weight-≤8 vectors. Log matrix + property proof; do NOT ship.
+- **E.2:** Smaller-step search — relax to entries ∈ {-8,…,8} (mul-by-≤8 = ≤3 adds), larger space, higher hit probability, smaller per-mul saving.
+
+### Constraint that filtered Target B from this pool
+
+Multi-query Merkle sibling-cache / zip-style transcript dedup was a strong paper-anchored candidate (eprint 2025/1446) but the trade-off is proof-size +10-30%. Under the Lean Ethereum 128 KiB target, proof-size regressions are no-go regardless of wall-clock win. **Do not propose any candidate that increases proof size.** HARD RULE 5's proof_size_check enforces this per-keep.
+
+## Eval gate
+
+```bash
+bash ~/zk-autoresearch/harness/leanmultisig/scripts/eval_paired.sh
+```
+That's it. Auto-chain handles env_preflight (pre-flight), drift abort (within run), correctness (separately invoked), cumulative on keep, Criterion ship-gate on keep. Exit 0 = keep, 1 = discard, 2 = infra error.
+
+## Logging — `iters.tsv`
+
+Path (explicit): `experiment_logs/leanMultisig/optimization/pw4_2_poseidon_m4m_2026-05-13/iters.tsv`. Pre-seed at iter 0 with this header row:
+
+```
+hypothesis_id	magnitude	predicted_pct	measured_pct	proof_kib	status	files_changed	rationale
+```
+
+Append one tab-separated row per attempt at keep/discard decision (orphans get their own row).
+
+Status enum (one of):
+- `keep` — passed gate + auto-chain (or ship-gate-conflict resolved keep)
+- `discard` — failed gate, classified as hypothesis-wrong or dead-end-after-2-attempts
+- `orphan` — measurement-edge per Phase 4 (d) with `|measured| ≥ 0.5%` AND `p_value < 0.10`
+- `dead-end` — 2 attempts exhausted without keep
+- `cryptanalysis-pending` — Target E candidate matrix logged, NOT shipped, NOT counted
+
+`hypothesis_id` groups multiple attempts under one hypothesis (e.g., `h1-attempt1`, `h1-attempt2`, then `h2-attempt1`). One row per attempt.
+
+## Stop criterion
+
+Stop after **12 consecutive zero-keep hypotheses**. Each hypothesis can have up to 2 attempts (initial + diagnostic-driven retry); both failing = 1 hypothesis exhausted = +1 toward counter. Any keep resets counter to 0.
+
+Counter exclusions:
+- Orphans don't count toward the counter (capped at 3 per session, see Phase 4)
+- `cryptanalysis-pending` rows don't count
+- Three consecutive eval exit-2 (infra error) results = pause for human intervention, NOT +1 (see Phase 3)
+- Abnormal session termination (context-window exhaustion, Cargo.lock corruption, disk-fill): write `verdict.md` with `status: aborted` + the reason, do not retry blindly
+
+On normal stop: write `verdict.md` (structured header per `context.md` schema) + `pr_body.md` (PR draft).
+
+## NEVER STOP
+
+Run autonomously until the 12-consecutive counter trips. No "I think I'm done" framing. The counter decides.


### PR DESCRIPTION
Forks pw4_2_poseidon_2026-05-13 → pw4_2_poseidon_m4m_2026-05-13 for parallel execution on Scaleway M4-M (Apple M4 base, 4P+6E, 32 GiB, macOS Sequoia, NEON 128-bit).

The two experiments race on independent branches against the same candidate pool; cross-platform delta becomes the post-run signal for which optimizations are silicon-portable.

Changes vs Hetzner sibling:
- Hardware section: M4 base (NOT M4 Pro per the brand string; ~120 GB/s LPDDR5X not 273 GB/s), macOS Sequoia 15.6.1, NEON only.
- Branch name: pw4_2-m4m-2026-05-13.
- HARD RULES: scalar-binding sub-investigation in compress_mut IS in scope on M4 (different ISA than Hetzner where pw4 already exhausted it). Sibling-experiment note added.
- profiling.md: full rewrite with M4-M baseline data from the parent profiling experiment (compress_mut 23.78% self, cvwait 18.54%, rayon plumbing 11.11%, Poseidon inclusive 58.23% of-CPU-bound, warm-proof wall 2.206 s).
- Bottleneck-shape map: M4-specific — adds P/E core affinity as potential huge lever, marks MADV_HUGEPAGE NULL on macOS, marks scalar-binding uncertain (NEON ≠ AVX-512).
- Profiling cheatsheet: sample / xctrace / dtrace / powermetrics instead of perf.
- Candidate pool: unchanged (same 4 broad targets). Agent will discover platform-specific NULL results during the run.

Executor prep already done (not in this commit):
- M4-M pulled to current main (b543153, matches Hetzner)
- Plonky3 on M4-M switched from crates-io-switch branch back to main
- sp1 + jolt cloned on M4-M (shallow depth 100) so inspiration repos list isn't broken