### PR TITLE
mechanism_inventory.yaml: Phase 1 depth gate + program.md integration

### DIFF
--- a/claude_hooks/phase_gate.sh
+++ b/claude_hooks/phase_gate.sh
@@ -65,7 +65,7 @@ CURRENT_ITER=$(cat "$ITER_FILE")
 REQUIRED_PAPERS=${PHASE1_PAPER_MINIMUM:-10}
 REQUIRED_PRIMITIVES=${PHASE1_PRIMITIVE_MINIMUM:-15}
 PAPERS_DIR="${REPORT_DIR}/papers/iter_${CURRENT_ITER}"
-INVENTORY_FILE="${REPORT_DIR}/mechanism_inventory.yaml"
+INVENTORY_FILE="${EXPERIMENT_DIR}/mechanism_inventory.yaml"
 
 # --- Helpers ---
 count_papers() {

--- a/experiment_logs/leanVM/autoresearcher/example/mechanism_inventory.yaml
+++ b/experiment_logs/leanVM/autoresearcher/example/mechanism_inventory.yaml
@@ -1,0 +1,54 @@
+# Mechanism Inventory — append-only across iterations
+#
+# Each paper decomposes into 2-4 typed primitives. The inventory is your
+# combination space: more primitives = more composition opportunities.
+#
+# The phase gate requires >= 15 primitives before implementation.
+# Papers in report/papers/iter_N/ satisfy the breadth gate.
+# This inventory satisfies the depth gate.
+
+primitives:
+  - id: p1
+    name: short-descriptive-name
+    source: "Author YYYY/NNNN §section"
+    mechanism: >
+      What it does in 1-3 sentences.
+    cost_model: >
+      What it saves, what it costs. Be quantitative.
+    assumptions:
+      pcs: any          # any | FRI | WHIR | KZG | MSM-class
+      field: any        # any | 31-bit | 64-bit | prime | binary
+      arch: any         # any | avx512 | neon | specific requirement
+      requires: ""      # other prerequisites (optional)
+    soundness_cost: "added error term or 'none'"
+    composable_with: [other-primitive-ids-or-names]
+    status: available   # available | used | closed
+    iter_added: 1
+
+  - id: p2
+    name: another-primitive
+    source: "Author YYYY/NNNN §section"
+    mechanism: >
+      Description.
+    cost_model: >
+      Quantitative cost/benefit.
+    assumptions:
+      pcs: any
+      field: any
+      arch: any
+    soundness_cost: none
+    composable_with: [p1]
+    status: available
+    iter_added: 1
+
+# Compositions: novel constructs from combining primitives.
+# At least one pool entry per iteration must be a composition.
+
+compositions:
+  - id: c1
+    name: descriptive-composition-name
+    composed_of: [p1, p2]
+    novel_claim: >
+      What this construct does that NEITHER source paper describes
+      individually. One sentence.
+    iter_added: 1

--- a/experiment_logs/leanVM/autoresearcher/goldilocks-ax42u/mechanism_inventory.yaml
+++ b/experiment_logs/leanVM/autoresearcher/goldilocks-ax42u/mechanism_inventory.yaml
@@ -1,0 +1,54 @@
+# Mechanism Inventory — append-only across iterations
+#
+# Each paper decomposes into 2-4 typed primitives. The inventory is your
+# combination space: more primitives = more composition opportunities.
+#
+# The phase gate requires >= 15 primitives before implementation.
+# Papers in report/papers/iter_N/ satisfy the breadth gate.
+# This inventory satisfies the depth gate.
+
+primitives:
+  - id: p1
+    name: short-descriptive-name
+    source: "Author YYYY/NNNN §section"
+    mechanism: >
+      What it does in 1-3 sentences.
+    cost_model: >
+      What it saves, what it costs. Be quantitative.
+    assumptions:
+      pcs: any          # any | FRI | WHIR | KZG | MSM-class
+      field: any        # any | 31-bit | 64-bit | prime | binary
+      arch: any         # any | avx512 | neon | specific requirement
+      requires: ""      # other prerequisites (optional)
+    soundness_cost: "added error term or 'none'"
+    composable_with: [other-primitive-ids-or-names]
+    status: available   # available | used | closed
+    iter_added: 1
+
+  - id: p2
+    name: another-primitive
+    source: "Author YYYY/NNNN §section"
+    mechanism: >
+      Description.
+    cost_model: >
+      Quantitative cost/benefit.
+    assumptions:
+      pcs: any
+      field: any
+      arch: any
+    soundness_cost: none
+    composable_with: [p1]
+    status: available
+    iter_added: 1
+
+# Compositions: novel constructs from combining primitives.
+# At least one pool entry per iteration must be a composition.
+
+compositions:
+  - id: c1
+    name: descriptive-composition-name
+    composed_of: [p1, p2]
+    novel_claim: >
+      What this construct does that NEITHER source paper describes
+      individually. One sentence.
+    iter_added: 1

--- a/experiment_logs/leanVM/autoresearcher/goldilocks-ax42u/program.md
+++ b/experiment_logs/leanVM/autoresearcher/goldilocks-ax42u/program.md
@@ -60,7 +60,7 @@ See chapters for substeps, order of operations
 
   1. Select your target
   2. Read  yourself (DO NOT use sub-agents for this) minimum 10 related research papers to develop 3 different hypothesis that can solve your target. Save them to `/report/papers/iter_{n}`
-  3. **Decompose each paper into typed primitives in report/mechanism_inventory.yaml** 
+  3. **Decompose each paper into typed primitives in mechanism_inventory.yaml** 
      (see example in experiment_logs/leanVM/autoresearcher/example/mechanism_inventory.yaml).
      Each paper should yield 2-4 primitives. The hook requires >= 15 primitives before 
      implementation. Review composable_with links for combination opportunities.

--- a/experiment_logs/leanVM/autoresearcher/goldilocks-ax42u/program.md
+++ b/experiment_logs/leanVM/autoresearcher/goldilocks-ax42u/program.md
@@ -60,11 +60,15 @@ See chapters for substeps, order of operations
 
   1. Select your target
   2. Read  yourself (DO NOT use sub-agents for this) minimum 10 related research papers to develop 3 different hypothesis that can solve your target. Save them to `/report/papers/iter_{n}`
-  3. Fill the pool with 3 initial candidates, based on your research. Add the papers you have read and you are using as citations.You need to develop composition techniques from different papers. 
-  4. Use a subagent for each candidate with the tool call `subagent_type: "Plan"`  mode to develop the implementation plan (save these to `report/hypothesis_N/{name_of_hypothesis}`)
+  3. **Decompose each paper into typed primitives in report/mechanism_inventory.yaml** 
+     (see example in experiment_logs/leanVM/autoresearcher/example/mechanism_inventory.yaml).
+     Each paper should yield 2-4 primitives. The hook requires >= 15 primitives before 
+     implementation. Review composable_with links for combination opportunities.
+  4. Fill the pool with 3 initial candidates, based on your research. Add the papers you have read and you are using as citations.You need to develop composition techniques from different papers. 
+  5. Use a subagent for each candidate with the tool call `subagent_type: "Plan"`  mode to develop the implementation plan (save these to `report/hypothesis_N/{name_of_hypothesis}`)
         Resources to hand off to the agent: Papers, Codebase understanding and tools to test. 
-  5. Review the implementation plans once they finish and calculate the impact for the predicted_pct field
-  6. Select by ambition: largest PROTOCOL DEPTH (changes verifier > changes prover round structure > changes prover implementation). Tiebreak: largest |predicted_pct|.
+  6. Review the implementation plans once they finish and calculate the impact for the predicted_pct field
+  7. Select by ambition: largest PROTOCOL DEPTH (changes verifier > changes prover round structure > changes prover implementation). Tiebreak: largest |predicted_pct|.
 
   Output artifacts: `zk-autoresearch/experiment_logs/leanVM/autoresearcher/goldilocks-ax42u/hypothesis_pool.yaml`
 
@@ -132,7 +136,7 @@ You are working in the leanVM repo. Only changes to this need to be commited. Lo
 ```bash
 bash ~/zk-autoresearch/harness/leanvm-goldilocks/correctness/correctness.sh
 ```
-Note: Use flag --expect-protected-changes mode if changes required verifier-depth work
+Note: Use --expect-protected-changes when the experiment intentionally modifies protected files (verifier, Fiat-Shamir, WHIR core, structural AIR methods). This runs all layers without fail-fast and reports protected-file changes as REVIEW instead of FAIL. todo!() and unimplemented!() always hard-fail regardless of mode.
 
 ## Evaluation Gate
 

--- a/experiment_logs/leanVM/autoresearcher/pw13-hetzner/mechanism_inventory.yaml
+++ b/experiment_logs/leanVM/autoresearcher/pw13-hetzner/mechanism_inventory.yaml
@@ -1,0 +1,54 @@
+# Mechanism Inventory — append-only across iterations
+#
+# Each paper decomposes into 2-4 typed primitives. The inventory is your
+# combination space: more primitives = more composition opportunities.
+#
+# The phase gate requires >= 15 primitives before implementation.
+# Papers in report/papers/iter_N/ satisfy the breadth gate.
+# This inventory satisfies the depth gate.
+
+primitives:
+  - id: p1
+    name: short-descriptive-name
+    source: "Author YYYY/NNNN §section"
+    mechanism: >
+      What it does in 1-3 sentences.
+    cost_model: >
+      What it saves, what it costs. Be quantitative.
+    assumptions:
+      pcs: any          # any | FRI | WHIR | KZG | MSM-class
+      field: any        # any | 31-bit | 64-bit | prime | binary
+      arch: any         # any | avx512 | neon | specific requirement
+      requires: ""      # other prerequisites (optional)
+    soundness_cost: "added error term or 'none'"
+    composable_with: [other-primitive-ids-or-names]
+    status: available   # available | used | closed
+    iter_added: 1
+
+  - id: p2
+    name: another-primitive
+    source: "Author YYYY/NNNN §section"
+    mechanism: >
+      Description.
+    cost_model: >
+      Quantitative cost/benefit.
+    assumptions:
+      pcs: any
+      field: any
+      arch: any
+    soundness_cost: none
+    composable_with: [p1]
+    status: available
+    iter_added: 1
+
+# Compositions: novel constructs from combining primitives.
+# At least one pool entry per iteration must be a composition.
+
+compositions:
+  - id: c1
+    name: descriptive-composition-name
+    composed_of: [p1, p2]
+    novel_claim: >
+      What this construct does that NEITHER source paper describes
+      individually. One sentence.
+    iter_added: 1

--- a/experiment_logs/leanVM/autoresearcher/pw13-hetzner/program.md
+++ b/experiment_logs/leanVM/autoresearcher/pw13-hetzner/program.md
@@ -60,7 +60,7 @@ See chapters for substeps, order of operations
 
   1. Select your target
   2. Read  yourself (DO NOT use sub-agents for this) minimum 10 related research papers to develop 3 different hypothesis that can solve your target. Save them to `/report/papers/iter_{n}`
-  3. **Decompose each paper into typed primitives in report/mechanism_inventory.yaml** 
+  3. **Decompose each paper into typed primitives in mechanism_inventory.yaml** 
      (see example in experiment_logs/leanVM/autoresearcher/example/mechanism_inventory.yaml).
      Each paper should yield 2-4 primitives. The hook requires >= 15 primitives before 
      implementation. Review composable_with links for combination opportunities.

--- a/experiment_logs/leanVM/autoresearcher/pw13-hetzner/program.md
+++ b/experiment_logs/leanVM/autoresearcher/pw13-hetzner/program.md
@@ -60,11 +60,15 @@ See chapters for substeps, order of operations
 
   1. Select your target
   2. Read  yourself (DO NOT use sub-agents for this) minimum 10 related research papers to develop 3 different hypothesis that can solve your target. Save them to `/report/papers/iter_{n}`
-  3. Fill the pool with 3 initial candidates, based on your research. Add the papers you have read and you are using as citations.You need to develop composition techniques from different papers. 
-  4. Use a subagent for each candidate with the tool call `subagent_type: "Plan"`  mode to develop the implementation plan (save these to `report/hypothesis_N/{name_of_hypothesis}`)
+  3. **Decompose each paper into typed primitives in report/mechanism_inventory.yaml** 
+     (see example in experiment_logs/leanVM/autoresearcher/example/mechanism_inventory.yaml).
+     Each paper should yield 2-4 primitives. The hook requires >= 15 primitives before 
+     implementation. Review composable_with links for combination opportunities.
+  4. Fill the pool with 3 initial candidates, based on your research. Add the papers you have read and you are using as citations.You need to develop composition techniques from different papers. 
+  5. Use a subagent for each candidate with the tool call `subagent_type: "Plan"`  mode to develop the implementation plan (save these to `report/hypothesis_N/{name_of_hypothesis}`)
         Resources to hand off to the agent: Papers, Codebase understanding and tools to test. 
-  5. Review the implementation plans once they finish and calculate the impact for the predicted_pct field
-  6. Select by ambition: largest PROTOCOL DEPTH (changes verifier > changes prover round structure > changes prover implementation). Tiebreak: largest |predicted_pct|.
+  6. Review the implementation plans once they finish and calculate the impact for the predicted_pct field
+  7. Select by ambition: largest PROTOCOL DEPTH (changes verifier > changes prover round structure > changes prover implementation). Tiebreak: largest |predicted_pct|.
 
   Output artifacts: `zk-autoresearch/experiment_logs/leanVM/autoresearcher/pw13-hetzner/hypothesis_pool.yaml`
 
@@ -132,7 +136,7 @@ You are working in the leanVM repo. Only changes to this need to be commited. Lo
 ```bash
 bash ~/zk-autoresearch/harness/leanvm/correctness/correctness.sh
 ```
-Note: Use flag --expect-protected-changes mode if changes required verifier-depth work
+Note: Use --expect-protected-changes when the experiment intentionally modifies protected files (verifier, Fiat-Shamir, WHIR core, structural AIR methods). This runs all layers without fail-fast and reports protected-file changes as REVIEW instead of FAIL. todo!() and unimplemented!() always hard-fail regardless of mode.
 
 ## Evaluation Gate
 


### PR DESCRIPTION
## Summary

- New `mechanism_inventory.yaml` template in `example/` — generic schema for typed primitives with composition tracking
- Phase 1 step 3 added to both `pw13-hetzner` and `goldilocks-ax42u` program.md files
- `--expect-protected-changes` note expanded in both program.md files
- Hook already on main (`phase_gate.sh` counts `- id:` entries, requires >= 15)

## What the inventory does

Each paper decomposes into 2-4 typed primitives with: mechanism, cost_model, assumptions (pcs/field/arch), soundness_cost, composable_with. The `composable_with` links create the combination index — two primitives listing each other = candidate composition.

Three Phase 1 gates (all must pass before implementation):
1. **Papers** (breadth): >= 10 PDFs in `report/papers/iter_N/`
2. **Reads** (engagement): >= 10 PDFs Read by the agent
3. **Primitives** (depth): >= 15 entries in `mechanism_inventory.yaml`

## Files

| File | Change |
|---|---|
| `example/mechanism_inventory.yaml` | New — generic template, no anchoring content |
| `pw13-hetzner/program.md` | Phase 1 step 3 + expect-protected note |
| `goldilocks-ax42u/program.md` | Same changes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)